### PR TITLE
chore(dx): add Biome, Lefthook, and editor workspace settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run bun check
+      - name: Typecheck & Biome
         run: bun check
 
       - name: Run bun test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 /.idea/
-/.vscode/
-/.zed/
 
 /node_modules
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.swp
 
 .gitogito.local.yml
+.gitogito.credentials.yml

--- a/.gitogito.yml
+++ b/.gitogito.yml
@@ -1,7 +1,0 @@
-language: en
-editor: zed --wait
-provider: OpenRouter
-model: tngtech/deepseek-r1t2-chimera:free
-color:
-  text: "#000000"
-  backgroundColor: "#000000"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -56,7 +56,7 @@
       }
     },
     "JSON": {
-      "language_servers": ["biome"],
+      "language_servers": ["biome", "..."],
       "formatter": {
         "language_server": {
           "name": "biome"
@@ -64,7 +64,7 @@
       }
     },
     "JSONC": {
-      "language_servers": ["biome"],
+      "language_servers": ["biome", "..."],
       "formatter": {
         "language_server": {
           "name": "biome"

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,92 @@
+{
+  "format_on_save": "on",
+  "languages": {
+    "JavaScript": {
+      "language_servers": [
+        "vtsls",
+        "biome",
+        "!deno",
+        "!typescript-language-server",
+        "!eslint"
+      ],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TypeScript": {
+      "language_servers": [
+        "vtsls",
+        "biome",
+        "!deno",
+        "!typescript-language-server",
+        "!eslint"
+      ],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TSX": {
+      "language_servers": [
+        "vtsls",
+        "biome",
+        "!deno",
+        "!typescript-language-server",
+        "!eslint"
+      ],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "JSON": {
+      "language_servers": ["biome"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      }
+    },
+    "JSONC": {
+      "language_servers": ["biome"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      }
+    }
+  },
+  "lsp": {
+    "vtsls": {
+      "initialization_options": {
+        "typescript": {
+          "tsdk": "./node_modules/typescript/lib"
+        },
+        "vtsls": {
+          "autoUseWorkspaceTsdk": true
+        }
+      }
+    },
+    "biome": {
+      "settings": {
+        "require_config_file": true
+      }
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/**/*.ts", "src/**/*.tsx"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off",
+        "useOptionalChain": "off"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "off",
+        "useJsxKeyInIterable": "off"
+      },
+      "style": {
+        "useTemplate": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off",
+        "noExplicitAny": "warn",
+        "useIterableCallbackReturn": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -28,11 +28,13 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.12",
         "@commitlint/config-conventional": "^20.5.0",
         "@types/diff": "^8.0.0",
         "@types/lodash": "^4.17.24",
         "@types/react": "^19.2.14",
         "bun-types": "^1.3.13",
+        "lefthook": "^2.1.6",
         "typescript": "^5.9.3",
       },
     },
@@ -49,6 +51,24 @@
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
 
     "@cliffy/command": ["@jsr/cliffy__command@1.0.1", "https://npm.jsr.io/~/11/@jsr/cliffy__command/1.0.1.tgz", { "dependencies": { "@jsr/cliffy__flags": "1.0.1", "@jsr/cliffy__internal": "1.0.1", "@jsr/cliffy__table": "1.0.1", "@jsr/std__fmt": "^1.0.9", "@jsr/std__semver": "^1.0.8", "@jsr/std__text": "^1.0.17" } }, "sha512-CuqiQnVjy6iHpIq5ORffHobL0KEF6YgY3+o5eRczOY9HHuD2cL11OiL0/TnE+rgNWv9x1IIEm1pVRPsr/d5vyg=="],
 
@@ -451,6 +471,28 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,3 @@
-# https://lefthook.dev/configuration/
-# Lefthook はローカルのみ。--no-verify や hooks 未導入を防ぐには GitHub Actions のままがよい。
 pre-commit:
   commands:
     biome:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+# https://lefthook.dev/configuration/
+# Lefthook はローカルのみ。--no-verify や hooks 未導入を防ぐには GitHub Actions のままがよい。
+pre-commit:
+  commands:
+    biome:
+      glob:
+        - "src/**/*.ts"
+        - "src/**/*.tsx"
+      stage_fixed: true
+      run: biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+    check:
+      run: bun check

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "gitogito": "./src/main.ts"
   },
   "scripts": {
+    "prepare": "lefthook install",
     "dev": "bun run src/main.ts",
-    "typecheck": "bunx tsc --noEmit",
-    "check": "bun run typecheck",
+    "check": "bun tsc --noEmit && biome check src",
+    "format": "biome format --write src",
+    "lint": "biome check src",
     "test": "bun test",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage"
   },
@@ -39,11 +41,13 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.12",
     "@commitlint/config-conventional": "^20.5.0",
     "@types/diff": "^8.0.0",
     "@types/lodash": "^4.17.24",
     "@types/react": "^19.2.14",
     "bun-types": "^1.3.13",
+    "lefthook": "^2.1.6",
     "typescript": "^5.9.3"
   }
 }

--- a/src/app/app_extra.ts
+++ b/src/app/app_extra.ts
@@ -1,14 +1,12 @@
-import type { AppDependencies } from "./store.ts";
+import { createEnvRepository } from "../repositories/env/env_repository.ts";
+import { GitRemoteRepositoryCliImpl } from "../repositories/git/remote_repository.ts";
 import { createConfigFile } from "../services/config/config_file.ts";
 import { createConfigService } from "../services/config/config_service.ts";
 import { createCredentialFile } from "../services/credential/credential_file.ts";
 import { createCredentialService } from "../services/credential/credential_service.ts";
-import { createEnvRepository } from "../repositories/env/env_repository.ts";
-import { GitRemoteRepositoryCliImpl } from "../repositories/git/remote_repository.ts";
+import type { AppDependencies } from "./store.ts";
 
-export function createAppDependencies(
-  overrides: Partial<AppDependencies> = {},
-): AppDependencies {
+export function createAppDependencies(overrides: Partial<AppDependencies> = {}): AppDependencies {
   const env = overrides.env ?? createEnvRepository();
   const configFile = createConfigFile(env);
   const credentialFile = createCredentialFile(env);
@@ -16,7 +14,8 @@ export function createAppDependencies(
   return {
     env,
     config: overrides.config ?? createConfigService(configFile),
-    credentials: overrides.credentials ?? createCredentialService({ envRepository: env, credentialFile }),
+    credentials:
+      overrides.credentials ?? createCredentialService({ envRepository: env, credentialFile }),
     gitRemoteRepository: overrides.gitRemoteRepository ?? new GitRemoteRepositoryCliImpl(),
   };
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,10 +1,6 @@
 import { useMemo } from "react";
 import type { RouteObject } from "react-router";
-import {
-  createMemoryRouter,
-  Outlet,
-  RouterProvider
-} from "react-router";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router";
 import { commitRoute } from "../features/commit/routes.tsx";
 import { configRoute } from "../features/config/routes.tsx";
 import { homeFallbackRoute, homeIndexRoute } from "../features/home/routes.tsx";
@@ -15,27 +11,23 @@ const routes = [
   {
     path: "/",
     element: <Outlet />,
-    children: [
-      homeFallbackRoute,
-      initRoute,
-      homeIndexRoute,
-      commitRoute,
-      issueRoute,
-      configRoute,
-    ],
+    children: [homeFallbackRoute, initRoute, homeIndexRoute, commitRoute, issueRoute, configRoute],
   } satisfies RouteObject,
 ];
 
-export function AppRouter({ initialPath = "/", params = {} }: { initialPath?: string, params?: Record<string, string> }) {
+export function AppRouter({
+  initialPath = "/",
+  params = {},
+}: {
+  initialPath?: string;
+  params?: Record<string, string>;
+}) {
   const router = useMemo(() => {
     const searchParams = new URLSearchParams(params);
     const queryString = searchParams.toString();
     const entry = queryString ? `${initialPath}?${queryString}` : initialPath;
 
-    return createMemoryRouter(
-      routes,
-      { initialEntries: [entry] },
-    );
+    return createMemoryRouter(routes, { initialEntries: [entry] });
   }, [initialPath, params]);
 
   return <RouterProvider router={router} />;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -4,10 +4,13 @@ import { configUiReducer } from "../features/config/config_page_slice.ts";
 import { configReducer } from "../features/config/config_slice.ts";
 import { issueReducer } from "../features/issue/issue_slice.ts";
 import { notificationsReducer } from "../features/notifications/notifications_slice.ts";
+import type { EnvRepository } from "../repositories/env/env_repository.ts";
+import { createEnvRepository } from "../repositories/env/env_repository.ts";
 import {
-  type ConfigService,
-  createConfigService,
-} from "../services/config/config_service.ts";
+  type GitRemoteRepository,
+  GitRemoteRepositoryCliImpl,
+} from "../repositories/git/remote_repository.ts";
+import { type ConfigService, createConfigService } from "../services/config/config_service.ts";
 import { ConfigSchema } from "../services/config/schema/config_schema.ts";
 import type { GlobalConfig } from "../services/config/schema/global_config_schema.ts";
 import type { LocalConfig } from "../services/config/schema/local_config_schema.ts";
@@ -16,12 +19,6 @@ import {
   type CredentialService,
   createCredentialService,
 } from "../services/credential/credential_service.ts";
-import type { EnvRepository } from "../repositories/env/env_repository.ts";
-import { createEnvRepository } from "../repositories/env/env_repository.ts";
-import {
-  type GitRemoteRepository,
-  GitRemoteRepositoryCliImpl,
-} from "../repositories/git/remote_repository.ts";
 
 export interface AppDependencies {
   env: EnvRepository;
@@ -45,7 +42,7 @@ export function createAppStore({
     globalConfig = {} as Partial<GlobalConfig>,
     projectConfig = {} as Partial<ProjectConfig>,
   } = {},
-  dependencies = createDefaultAppDependencies()
+  dependencies = createDefaultAppDependencies(),
 }: {
   config?: {
     mergedConfig?: ReturnType<typeof ConfigSchema.parse>;
@@ -58,7 +55,7 @@ export function createAppStore({
   return configureStore({
     reducer,
     preloadedState: {
-      config: { mergedConfig, localConfig, globalConfig, projectConfig }
+      config: { mergedConfig, localConfig, globalConfig, projectConfig },
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({

--- a/src/commands/commit.test.ts
+++ b/src/commands/commit.test.ts
@@ -1,4 +1,4 @@
-import { mock, test, expect, beforeEach } from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
 
 mock.module("../lib/runner.tsx", () => ({
   runTuiWithRedux: mock(() => Promise.resolve()),
@@ -15,9 +15,7 @@ beforeEach(() => {
 });
 
 test("description が設定されている", () => {
-  expect(createCommitCommand().getDescription()).toBe(
-    "Commit changes to the repository",
-  );
+  expect(createCommitCommand().getDescription()).toBe("Commit changes to the repository");
 });
 
 test("parse() で runTuiWithRedux が呼ばれる", async () => {

--- a/src/commands/commit.tsx
+++ b/src/commands/commit.tsx
@@ -1,15 +1,11 @@
 import { Command } from "@cliffy/command";
 import { createAppDependencies } from "../app/app_extra.ts";
-import type { AppDependencies } from "../app/store.ts";
 import { AppRouter } from "../app/router.tsx";
+import type { AppDependencies } from "../app/store.ts";
 import { runTuiWithRedux } from "../lib/runner.tsx";
 
-export function createCommitCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
-  return new Command()
-    .description("Commit changes to the repository")
-    .action(async () => {
-      await runTuiWithRedux(<AppRouter initialPath="/commit" />, { dependencies });
-    });
+export function createCommitCommand(dependencies: AppDependencies = createAppDependencies()) {
+  return new Command().description("Commit changes to the repository").action(async () => {
+    await runTuiWithRedux(<AppRouter initialPath="/commit" />, { dependencies });
+  });
 }

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,5 +1,5 @@
-import { Command } from "@cliffy/command";
 import { expect, mock, test } from "bun:test";
+import { Command } from "@cliffy/command";
 import type { AppDependencies } from "../app/store.ts";
 import type { ConfigScope } from "../services/config/config_file.ts";
 import type { ConfigService } from "../services/config/config_service.ts";
@@ -52,7 +52,9 @@ function buildTestCommand(saveConfig = makeSaveConfig()) {
       getMergedCredentials: mock(() => Promise.resolve({})),
       saveCredentials: mock(() => Promise.resolve()),
     },
-    gitRemoteRepository: { getOwnerAndRepo: mock(() => Promise.resolve({ owner: "o", repo: "r" })) },
+    gitRemoteRepository: {
+      getOwnerAndRepo: mock(() => Promise.resolve({ owner: "o", repo: "r" })),
+    },
   };
 
   const root = new Command()

--- a/src/commands/config.tsx
+++ b/src/commands/config.tsx
@@ -1,11 +1,11 @@
 import { Command } from "@cliffy/command";
 import { createAppDependencies } from "../app/app_extra.ts";
-import type { AppDependencies } from "../app/store.ts";
 import { AppRouter } from "../app/router.tsx";
+import type { AppDependencies } from "../app/store.ts";
 import { flatSchema, fullPath, urlPath } from "../helpers/flat_schema.ts";
 import { runTuiWithRedux } from "../lib/runner.tsx";
 import type { ConfigScope } from "../services/config/config_file.ts";
-import { ConfigSchema, type Config } from "../services/config/schema/config_schema.ts";
+import { type Config, ConfigSchema } from "../services/config/schema/config_schema.ts";
 import type { NestedKeys } from "../type.ts";
 
 export type ConfigCommandOptions = {
@@ -35,11 +35,11 @@ export function buildSubcommands(
 
     const itemFullPath = fullPath(item);
     const itemUrlPath = urlPath(item);
-    const cmd = new Command<ConfigCommandOptions>()
-      .description(`Configure ${itemFullPath}`);
+    const cmd = new Command<ConfigCommandOptions>().description(`Configure ${itemFullPath}`);
 
     if (item.isLeaf) {
-      cmd.option("--set <value:string>", "Set value for this config key.")
+      cmd
+        .option("--set <value:string>", "Set value for this config key.")
         .action(async (options: ConfigSetCommandOptions) => {
           const scope = resolveScope(options);
           if (options.set) {
@@ -82,9 +82,7 @@ export function buildSubcommands(
   }
 }
 
-export function createConfigCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
+export function createConfigCommand(dependencies: AppDependencies = createAppDependencies()) {
   const command = new Command()
     .description("Configure the repository")
     .globalOption("--project", "Set project settings.", {
@@ -98,7 +96,9 @@ export function createConfigCommand(
     })
     .action(async (options: ConfigCommandOptions) => {
       const scope = resolveScope(options);
-      await runTuiWithRedux(<AppRouter initialPath="/config" params={{ scope }} />, { dependencies });
+      await runTuiWithRedux(<AppRouter initialPath="/config" params={{ scope }} />, {
+        dependencies,
+      });
     });
 
   buildSubcommands(command, flatSchema(ConfigSchema), dependencies);

--- a/src/commands/doctor.tsx
+++ b/src/commands/doctor.tsx
@@ -1,16 +1,11 @@
 import { Command } from "@cliffy/command";
 import { createAppDependencies } from "../app/app_extra.ts";
-import type { AppDependencies } from "../app/store.ts";
 import { AppRouter } from "../app/router.tsx";
+import type { AppDependencies } from "../app/store.ts";
 import { runTuiWithRedux } from "../lib/runner.tsx";
 
-
-export function createDoctorCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
-  return new Command()
-    .description("Check the health of the project")
-    .action(async () => {
-      await runTuiWithRedux(<AppRouter initialPath="/doctor" />, { dependencies });
-    });
+export function createDoctorCommand(dependencies: AppDependencies = createAppDependencies()) {
+  return new Command().description("Check the health of the project").action(async () => {
+    await runTuiWithRedux(<AppRouter initialPath="/doctor" />, { dependencies });
+  });
 }

--- a/src/commands/init.tsx
+++ b/src/commands/init.tsx
@@ -1,15 +1,11 @@
 import { Command } from "@cliffy/command";
 import { createAppDependencies } from "../app/app_extra.ts";
-import type { AppDependencies } from "../app/store.ts";
 import { AppRouter } from "../app/router.tsx";
+import type { AppDependencies } from "../app/store.ts";
 import { runTuiWithRedux } from "../lib/runner.tsx";
 
-export function createInitCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
-  return new Command()
-    .description("Initialize a new project")
-    .action(async () => {
-      await runTuiWithRedux(<AppRouter initialPath="/init" />, { dependencies });
-    });
+export function createInitCommand(dependencies: AppDependencies = createAppDependencies()) {
+  return new Command().description("Initialize a new project").action(async () => {
+    await runTuiWithRedux(<AppRouter initialPath="/init" />, { dependencies });
+  });
 }

--- a/src/commands/issue.tsx
+++ b/src/commands/issue.tsx
@@ -1,15 +1,11 @@
 import { Command } from "@cliffy/command";
 import { createAppDependencies } from "../app/app_extra.ts";
-import type { AppDependencies } from "../app/store.ts";
 import { AppRouter } from "../app/router.tsx";
+import type { AppDependencies } from "../app/store.ts";
 import { runTuiWithRedux } from "../lib/runner.tsx";
 
-export function createIssueCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
-  return new Command()
-    .description("Manage issues in the repository")
-    .action(async () => {
-      await runTuiWithRedux(<AppRouter initialPath="/issue" />, { dependencies });
-    });
+export function createIssueCommand(dependencies: AppDependencies = createAppDependencies()) {
+  return new Command().description("Manage issues in the repository").action(async () => {
+    await runTuiWithRedux(<AppRouter initialPath="/issue" />, { dependencies });
+  });
 }

--- a/src/components/AgentLoop.tsx
+++ b/src/components/AgentLoop.tsx
@@ -5,9 +5,9 @@ import { useAppDependencies } from "../contexts/app_dependencies_context.tsx";
 import { IssueAgentSchema, type IssueSchema } from "../schema.ts";
 import { AIService } from "../services/ai/ai_service.ts";
 import type { UsageCallback } from "../services/ai/types.ts";
-import { Box } from "./ThemedComponents.tsx";
 import { Spinner } from "./Spinner.tsx";
 import { TextInput } from "./TextInput.tsx";
+import { Box } from "./ThemedComponents.tsx";
 
 export function AgentLoop({
   initialMessages,
@@ -26,10 +26,7 @@ export function AgentLoop({
 
   const performStep = async () => {
     try {
-      const aiService = await AIService.create(
-        dependencies.config,
-        dependencies.credentials,
-      );
+      const aiService = await AIService.create(dependencies.config, dependencies.credentials);
       const completion = await aiService.generateStructuredOutput(
         history,
         "issueAgent",
@@ -56,11 +53,7 @@ export function AgentLoop({
   };
 
   if (status === "thinking") {
-    return (
-      <Spinner
-        handleDataLoading={performStep}
-      />
-    );
+    return <Spinner handleDataLoading={performStep} />;
   }
 
   const currentQ = questions[currentQuestionIndex];

--- a/src/components/Carousel.test.ts
+++ b/src/components/Carousel.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import {
   CAROUSEL_EMPTY_MESSAGE,
-  getSafeCarouselIndex,
   getCarouselPositionLabel,
+  getSafeCarouselIndex,
 } from "./Carousel.tsx";
 
 test("getCarouselPositionLabel uses zero when there are no choices", () => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -2,7 +2,6 @@ import { TextAttributes } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useState } from "react";
 import { useThemeColors } from "../features/config/use_theme_colors.ts";
-import { useThemeMode } from "../contexts/theme_mode_context.tsx";
 import { isCtrlC, isEnter } from "../helpers/opentui/key.ts";
 import { Box, Text } from "./ThemedComponents.tsx";
 // import { renderTui } from "../lib/opentui_render.tsx";
@@ -19,20 +18,13 @@ interface CarouselProps<T> {
   onSelect: (value: T | undefined) => void;
 }
 
-export const CAROUSEL_EMPTY_MESSAGE =
-  "No options available. Press Enter or Esc to go back.";
+export const CAROUSEL_EMPTY_MESSAGE = "No options available. Press Enter or Esc to go back.";
 
-export function getCarouselPositionLabel(
-  selectedIndex: number,
-  choiceCount: number,
-) {
+export function getCarouselPositionLabel(selectedIndex: number, choiceCount: number) {
   return `← ${choiceCount > 0 ? selectedIndex + 1 : 0}/${choiceCount} →`;
 }
 
-export function getSafeCarouselIndex(
-  selectedIndex: number,
-  choiceCount: number,
-) {
+export function getSafeCarouselIndex(selectedIndex: number, choiceCount: number) {
   return choiceCount > 0 ? Math.max(0, Math.min(selectedIndex, choiceCount - 1)) : 0;
 }
 
@@ -43,8 +35,6 @@ export function Carousel<T>({ message, choices, onSelect }: CarouselProps<T>) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const hasChoices = choices.length > 0;
   const safeSelectedIndex = getSafeCarouselIndex(selectedIndex, choices.length);
-  const themeMode = useThemeMode();
-
 
   useKeyboard((event) => {
     if (event.name === "escape" || isCtrlC(event)) {
@@ -86,31 +76,27 @@ export function Carousel<T>({ message, choices, onSelect }: CarouselProps<T>) {
         <Text attributes={TextAttributes.DIM}>(Enter to Select)</Text>
       </Box>
 
-      {hasChoices
-        ? (
-          <Box
-            flexDirection="column"
-            border
-            borderStyle="rounded"
-            borderColor={themeColors.primary}
-            paddingLeft={1}
-            paddingRight={1}
-          >
-            <Text attributes={TextAttributes.BOLD} fg={themeColors.primary} truncate>
-              {choices[safeSelectedIndex].name}
-            </Text>
-            {choices[safeSelectedIndex].description && (
-              <Box marginTop={1}>
-                <Text>{choices[safeSelectedIndex].description}</Text>
-              </Box>
-            )}
-          </Box>
-        )
-        : (
-          <Text attributes={TextAttributes.DIM}>
-            {CAROUSEL_EMPTY_MESSAGE}
+      {hasChoices ? (
+        <Box
+          flexDirection="column"
+          border
+          borderStyle="rounded"
+          borderColor={themeColors.primary}
+          paddingLeft={1}
+          paddingRight={1}
+        >
+          <Text attributes={TextAttributes.BOLD} fg={themeColors.primary} truncate>
+            {choices[safeSelectedIndex].name}
           </Text>
-        )}
+          {choices[safeSelectedIndex].description && (
+            <Box marginTop={1}>
+              <Text>{choices[safeSelectedIndex].description}</Text>
+            </Box>
+          )}
+        </Box>
+      ) : (
+        <Text attributes={TextAttributes.DIM}>{CAROUSEL_EMPTY_MESSAGE}</Text>
+      )}
     </Box>
   );
 }

--- a/src/components/ConsolePanel.tsx
+++ b/src/components/ConsolePanel.tsx
@@ -1,4 +1,4 @@
-import { ScrollBoxRenderable, TextAttributes } from "@opentui/core";
+import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core";
 import { useEffect, useRef, useState } from "react";
 import { useThemeColors } from "../features/config/use_theme_colors.ts";
 import { Box, ScrollBox, Text } from "./ThemedComponents.tsx";
@@ -17,11 +17,7 @@ export interface ConsolePanelProps {
   width?: number | `${number}%` | "auto";
 }
 
-export const ConsolePanel = ({
-  maxLines = 5,
-  height = 7,
-  width = "100%",
-}: ConsolePanelProps) => {
+export const ConsolePanel = ({ maxLines = 5, height = 7, width = "100%" }: ConsolePanelProps) => {
   const theme = useThemeColors();
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const scrollboxRef = useRef<ScrollBoxRenderable | null>(null);
@@ -37,11 +33,9 @@ export const ConsolePanel = ({
 
     for (const level of levels) {
       originals.current[level] = console[level].bind(console);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // biome-ignore lint/suspicious/noExplicitAny: patch console by dynamic log level for capture
       (console as any)[level] = (...args: unknown[]) => {
-        const message = args
-          .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
-          .join(" ");
+        const message = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ");
         // Defer to avoid calling setState during React reconciliation
         setTimeout(() => {
           setEntries((prev) => [...prev, { level, message }]);
@@ -51,7 +45,7 @@ export const ConsolePanel = ({
 
     return () => {
       for (const level of levels) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // biome-ignore lint/suspicious/noExplicitAny: restore patched console methods
         (console as any)[level] = originals.current[level];
       }
     };

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -15,9 +15,7 @@ type LogoSegment = {
 };
 
 const art: ReadonlyArray<ReadonlyArray<LogoSegment>> = [
-  [
-    { text: " ,／⌒八⌒＼、", fg: yellow },
-  ],
+  [{ text: " ,／⌒八⌒＼、", fg: yellow }],
   [
     { text: "／", fg: yellow },
     { text: "／", fg: orange },
@@ -95,22 +93,13 @@ const art: ReadonlyArray<ReadonlyArray<LogoSegment>> = [
     { text: " ,,＿＿＿＿,, ", attributes: TextAttributes.DIM },
     { text: "）））", fg: orange },
   ],
-  [
-    { text: "＼＼＿＿＿＿＿＿／／", fg: orange },
-  ],
-  [
-    { text: "～＊～＊～＊～＊～＊～＊～＊～", fg: gold },
-  ],
+  [{ text: "＼＼＿＿＿＿＿＿／／", fg: orange }],
+  [{ text: "～＊～＊～＊～＊～＊～＊～＊～", fg: gold }],
 ];
 
 export function Logo() {
   return (
-    <Box
-      width={30}
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-    >
+    <Box width={30} flexDirection="column" justifyContent="center" alignItems="center">
       {art.map((row, rowIndex) => (
         <Box key={rowIndex} flexDirection="row">
           {row.map((segment, segmentIndex) => (

--- a/src/components/Select.test.ts
+++ b/src/components/Select.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from "bun:test";
-import {
-  getSafeSelectIndex,
-  getSelectPositionLabel,
-  SELECT_EMPTY_MESSAGE,
-} from "./Select.tsx";
+import { getSafeSelectIndex, getSelectPositionLabel, SELECT_EMPTY_MESSAGE } from "./Select.tsx";
 
 test("getSelectPositionLabel uses zero when there are no choices", () => {
   expect(getSelectPositionLabel(0, 0)).toBe("(0/0)");

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -2,11 +2,11 @@ import { TextAttributes } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useState } from "react";
 import { SELECT_EMPTY_MESSAGE } from "../constants/message.ts";
-import { isCtrlC, isEnter } from "../helpers/opentui/key.ts";
 // import { renderTui } from "../lib/opentui_render.tsx";
 import { useThemeColors } from "../features/config/use_theme_colors.ts";
-import { Box, Text } from "./ThemedComponents.tsx";
+import { isCtrlC, isEnter } from "../helpers/opentui/key.ts";
 import type { Choice } from "../type.ts";
+import { Box, Text } from "./ThemedComponents.tsx";
 
 export { SELECT_EMPTY_MESSAGE };
 
@@ -18,10 +18,7 @@ type SelectOptions<T> = {
   initialIndex?: number;
 };
 
-export function getSelectPositionLabel(
-  selectedIndex: number,
-  choiceCount: number,
-) {
+export function getSelectPositionLabel(selectedIndex: number, choiceCount: number) {
   return `(${choiceCount > 0 ? selectedIndex + 1 : 0}/${choiceCount})`;
 }
 
@@ -35,10 +32,7 @@ export function Select<T>(options: SelectOptions<T>) {
   const themeColors = useThemeColors();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const hasChoices = options.choices.length > 0;
-  const safeSelectedIndex = getSafeSelectIndex(
-    selectedIndex,
-    options.choices.length,
-  );
+  const safeSelectedIndex = getSafeSelectIndex(selectedIndex, options.choices.length);
 
   useKeyboard((event) => {
     if (isCtrlC(event)) {
@@ -66,9 +60,7 @@ export function Select<T>(options: SelectOptions<T>) {
     }
 
     if (event.name === "up") {
-      setSelectedIndex((prev) =>
-        (prev - 1 + options.choices.length) % options.choices.length
-      );
+      setSelectedIndex((prev) => (prev - 1 + options.choices.length) % options.choices.length);
     }
 
     if (event.name === "down") {
@@ -88,14 +80,11 @@ export function Select<T>(options: SelectOptions<T>) {
           {getSelectPositionLabel(safeSelectedIndex, options.choices.length)}
         </Text>
       </Box>
-      {hasChoices
-        ? options.choices.map((value, index) => {
+      {hasChoices ? (
+        options.choices.map((value, index) => {
           const isSelected = safeSelectedIndex === index;
           return (
-            <Box
-              key={value.name}
-              flexDirection="column"
-            >
+            <Box key={value.name} flexDirection="column">
               <Text
                 attributes={TextAttributes.BOLD}
                 truncate
@@ -104,25 +93,16 @@ export function Select<T>(options: SelectOptions<T>) {
                 {`→ ${value.name}`}
               </Text>
               {isSelected && (
-                <Box
-                  paddingLeft={1}
-                  borderStyle="single"
-                  border={[
-                    "left",
-                  ]}
-                  borderColor="gray"
-                >
+                <Box paddingLeft={1} borderStyle="single" border={["left"]} borderColor="gray">
                   <Text attributes={TextAttributes.DIM}>{`${value.description}`}</Text>
                 </Box>
               )}
             </Box>
           );
         })
-        : (
-          <Text attributes={TextAttributes.DIM}>
-            {SELECT_EMPTY_MESSAGE}
-          </Text>
-        )}
+      ) : (
+        <Text attributes={TextAttributes.DIM}>{SELECT_EMPTY_MESSAGE}</Text>
+      )}
     </Box>
   );
 }

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { cycleZip } from "../helpers/collections/cycle_zip.ts";
+
 // import { renderTui } from "../lib/opentui_render.tsx";
 
 type Frame = {
@@ -23,9 +24,11 @@ class FrameBuilder {
   }
 
   addSpace() {
-    this.frames = cycleZip(this.frames, [{
-      frames: [{ color: undefined, text: " " }],
-    }]).map((v) => ({ frames: [...v[0].frames, ...v[1].frames] }));
+    this.frames = cycleZip(this.frames, [
+      {
+        frames: [{ color: undefined, text: " " }],
+      },
+    ]).map((v) => ({ frames: [...v[0].frames, ...v[1].frames] }));
     return this;
   }
 
@@ -57,12 +60,13 @@ const defaultFrame = new FrameBuilder()
   .addFrame([undefined], frames2)
   .build();
 
-export function Spinner(
-  { frame = defaultFrame, handleDataLoading }: {
-    frame?: Frame[];
-    handleDataLoading: () => Promise<void>;
-  },
-) {
+export function Spinner({
+  frame = defaultFrame,
+  handleDataLoading,
+}: {
+  frame?: Frame[];
+  handleDataLoading: () => Promise<void>;
+}) {
   const [frameIndex, setFrameIndex] = useState(0);
 
   useEffect(() => {
@@ -81,7 +85,11 @@ export function Spinner(
   return (
     <box paddingLeft={1} paddingRight={1}>
       {frame[frameIndex].frames.map((v, i) => {
-        return <text key={i} fg={v.color}>{v.text}</text>;
+        return (
+          <text key={i} fg={v.color}>
+            {v.text}
+          </text>
+        );
       })}
     </box>
   );

--- a/src/components/SplitPane.test.tsx
+++ b/src/components/SplitPane.test.tsx
@@ -1,10 +1,11 @@
-import { testRender } from "@opentui/react/test-utils";
 import { expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
 import { Provider } from "react-redux";
 import { createAppStore } from "../app/store.ts";
+import { ThemeModeProvider } from "../contexts/theme_mode_context.tsx";
 import { ConfigSchema } from "../services/config/schema/config_schema.ts";
-import { SplitPane, parseDefaultSize } from "./SplitPane.tsx";
+import { parseDefaultSize, SplitPane } from "./SplitPane.tsx";
 
 // ---------------------------------------------------------------------------
 // parseDefaultSize — pure unit tests (no renderer needed)
@@ -45,7 +46,11 @@ function makeStore() {
 }
 
 function wrap(node: React.ReactNode) {
-  return <Provider store={makeStore()}>{node}</Provider>;
+  return (
+    <Provider store={makeStore()}>
+      <ThemeModeProvider>{node}</ThemeModeProvider>
+    </Provider>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -54,11 +59,7 @@ function wrap(node: React.ReactNode) {
 
 test("SplitPane renders content of both panes", async () => {
   const tui = await testRender(
-    wrap(
-      <SplitPane>
-        {[<text>left-pane</text>, <text>right-pane</text>]}
-      </SplitPane>,
-    ),
+    wrap(<SplitPane>{[<text>left-pane</text>, <text>right-pane</text>]}</SplitPane>),
     { width: 80, height: 24 },
   );
 
@@ -68,7 +69,9 @@ test("SplitPane renders content of both panes", async () => {
   expect(frame).toContain("left-pane");
   expect(frame).toContain("right-pane");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 test("SplitPane horizontal: first pane occupies defaultSize columns", async () => {
@@ -89,7 +92,9 @@ test("SplitPane horizontal: first pane occupies defaultSize columns", async () =
   expect(frame).toContain("BBBB");
   expect(frame).toContain("┃");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 test("SplitPane horizontal: percentage defaultSize renders both panes", async () => {
@@ -108,7 +113,9 @@ test("SplitPane horizontal: percentage defaultSize renders both panes", async ()
   expect(frame).toContain("LEFT");
   expect(frame).toContain("RIGHT");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -132,7 +139,9 @@ test("SplitPane vertical: renders both panes stacked", async () => {
   expect(frame).toContain("BOTTOM");
   expect(frame).toContain("━━");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -153,7 +162,9 @@ test("SplitPane horizontal: dragging divider right increases first pane", async 
   await tui.renderOnce();
 
   // Drag divider 10 columns to the right — first pane should grow to 40
-  await act(async () => { await tui.mockMouse.drag(30, 5, 40, 5); });
+  await act(async () => {
+    await tui.mockMouse.drag(30, 5, 40, 5);
+  });
   await tui.renderOnce();
 
   // Both panes must still be visible after drag
@@ -161,7 +172,9 @@ test("SplitPane horizontal: dragging divider right increases first pane", async 
   expect(frame).toContain("FIRST");
   expect(frame).toContain("SECOND");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 test("SplitPane horizontal: dragging divider left shrinks first pane", async () => {
@@ -177,14 +190,18 @@ test("SplitPane horizontal: dragging divider left shrinks first pane", async () 
   await tui.renderOnce();
 
   // Drag divider 10 columns to the left
-  await act(async () => { await tui.mockMouse.drag(40, 5, 30, 5); });
+  await act(async () => {
+    await tui.mockMouse.drag(40, 5, 30, 5);
+  });
   await tui.renderOnce();
 
   const frame = tui.captureCharFrame();
   expect(frame).toContain("FIRST");
   expect(frame).toContain("SECOND");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 test("SplitPane respects minSize when dragging past boundary", async () => {
@@ -200,7 +217,9 @@ test("SplitPane respects minSize when dragging past boundary", async () => {
   await tui.renderOnce();
 
   // Attempt to drag divider all the way to x=0 (past minSize=10)
-  await act(async () => { await tui.mockMouse.drag(20, 5, 0, 5); });
+  await act(async () => {
+    await tui.mockMouse.drag(20, 5, 0, 5);
+  });
   await tui.renderOnce();
 
   // Both panes still visible — first pane should be clamped to minSize (10)
@@ -208,7 +227,9 @@ test("SplitPane respects minSize when dragging past boundary", async () => {
   expect(frame).toContain("FIRST");
   expect(frame).toContain("SECOND");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -228,12 +249,16 @@ test("SplitPane vertical: dragging divider down increases first pane", async () 
   await tui.renderOnce();
 
   // Drag divider 4 rows down
-  await act(async () => { await tui.mockMouse.drag(10, 8, 10, 12); });
+  await act(async () => {
+    await tui.mockMouse.drag(10, 8, 10, 12);
+  });
   await tui.renderOnce();
 
   const frame = tui.captureCharFrame();
   expect(frame).toContain("TOP");
   expect(frame).toContain("BOTTOM");
 
-  act(() => { tui.renderer.destroy(); });
+  act(() => {
+    tui.renderer.destroy();
+  });
 });

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -15,10 +15,7 @@ export type SplitPaneProps = {
   children: [React.ReactNode, React.ReactNode];
 };
 
-export function parseDefaultSize(
-  defaultSize: number | string,
-  containerSize: number,
-): number {
+export function parseDefaultSize(defaultSize: number | string, containerSize: number): number {
   if (typeof defaultSize === "number") {
     return defaultSize;
   }
@@ -40,10 +37,7 @@ function clampDividerPosition(
   const lastValidPosition = Math.max(containerSize - 1, 0);
   const minPosition = Math.min(minSize, lastValidPosition);
   const maxPositionFromMinSize = Math.max(lastValidPosition - minSize, 0);
-  let maxPosition = Math.min(
-    maxSize ?? maxPositionFromMinSize,
-    lastValidPosition,
-  );
+  let maxPosition = Math.min(maxSize ?? maxPositionFromMinSize, lastValidPosition);
 
   if (maxPosition < minPosition) {
     maxPosition = lastValidPosition;
@@ -64,10 +58,12 @@ export function SplitPane({
   const setPointer = useMousePointer();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const [dividerPosition, setDividerPosition] = useState(30);
 
   const isHorizontal = direction === "horizontal";
   const containerSize = isHorizontal ? width : height;
+  const [dividerPosition, setDividerPosition] = useState(() =>
+    parseDefaultSize(defaultSize, Math.max(containerSize, 1)),
+  );
   const dividerLength = Math.max(isHorizontal ? height : width, 1);
   const clampedDividerPosition = clampDividerPosition(
     dividerPosition,
@@ -101,12 +97,9 @@ export function SplitPane({
           return;
         }
 
-        setDividerPosition(clampDividerPosition(
-          isHorizontal ? event.x : event.y,
-          containerSize,
-          minSize,
-          maxSize,
-        ));
+        setDividerPosition(
+          clampDividerPosition(isHorizontal ? event.x : event.y, containerSize, minSize, maxSize),
+        );
       }}
       onMouseUp={() => {
         clearHoverTimer();
@@ -152,19 +145,16 @@ export function SplitPane({
           setIsDragging(false);
           setPointer("default");
         }}
-
       >
-        {isHorizontal
-          ? Array.from({ length: dividerLength }, (_, index) => (
+        {isHorizontal ? (
+          Array.from({ length: dividerLength }, (_, index) => (
             <Text key={index} color="primary">
               ┃
             </Text>
           ))
-          : (
-            <Text color="primary">
-              {"━".repeat(dividerLength)}
-            </Text>
-          )}
+        ) : (
+          <Text color="primary">{"━".repeat(dividerLength)}</Text>
+        )}
       </Box>
       <Box
         flexGrow={1}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,18 +1,20 @@
 import { TextAttributes } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useEffect, useState } from "react";
-import { Box, Text } from "./ThemedComponents.tsx";
 import { useThemeColors } from "../features/config/use_theme_colors.ts";
 import { isCtrlC, isEnter, keyEventToInput } from "../helpers/opentui/key.ts";
+import { Box, Text } from "./ThemedComponents.tsx";
 // import { renderTui } from "../lib/opentui_render.tsx";
 
-export function TextInput(
-  { label, isInline, onSubmit }: {
-    label: string;
-    isInline?: boolean;
-    onSubmit: (val: string) => void;
-  },
-) {
+export function TextInput({
+  label,
+  isInline,
+  onSubmit,
+}: {
+  label: string;
+  isInline?: boolean;
+  onSubmit: (val: string) => void;
+}) {
   const themeColors = useThemeColors();
   const [value, setValue] = useState("");
   const [cursorPosition, setCursorPosition] = useState(0);
@@ -53,9 +55,7 @@ export function TextInput(
 
     if (event.name === "backspace" || event.name === "delete" || event.name === "forwarddelete") {
       if (cursorPosition > 0) {
-        setValue((v) =>
-          v.slice(0, cursorPosition - 1) + v.slice(cursorPosition)
-        );
+        setValue((v) => v.slice(0, cursorPosition - 1) + v.slice(cursorPosition));
         setCursorPosition((p) => p - 1);
       }
       return;
@@ -72,9 +72,7 @@ export function TextInput(
     }
 
     if (!event.ctrl && !event.meta && input.length > 0) {
-      setValue((v) =>
-        v.slice(0, cursorPosition) + input + v.slice(cursorPosition)
-      );
+      setValue((v) => v.slice(0, cursorPosition) + input + v.slice(cursorPosition));
       setCursorPosition((p) => p + input.length);
     }
   });
@@ -86,31 +84,23 @@ export function TextInput(
   return (
     <Box flexDirection={isInline ? "row" : "column"}>
       <Text attributes={TextAttributes.BOLD}>{label}</Text>
-      {isInline
-        ? (
-          <Box flexDirection="row">
-            <text fg={themeColors.primary}>{before}</text>
-            <text
-              fg={themeColors.primary}
-              attributes={showCursor ? TextAttributes.INVERSE : 0}
-            >
-              {charAtCursor}
-            </text>
-            <text fg={themeColors.primary}>{after}</text>
-          </Box>
-        )
-        : (
-          <Box>
-            <text fg={themeColors.primary}>{before}</text>
-            <text
-              fg={themeColors.primary}
-              attributes={showCursor ? TextAttributes.INVERSE : 0}
-            >
-              {charAtCursor}
-            </text>
-            <text fg={themeColors.primary}>{after}</text>
-          </Box>
-        )}
+      {isInline ? (
+        <Box flexDirection="row">
+          <text fg={themeColors.primary}>{before}</text>
+          <text fg={themeColors.primary} attributes={showCursor ? TextAttributes.INVERSE : 0}>
+            {charAtCursor}
+          </text>
+          <text fg={themeColors.primary}>{after}</text>
+        </Box>
+      ) : (
+        <Box>
+          <text fg={themeColors.primary}>{before}</text>
+          <text fg={themeColors.primary} attributes={showCursor ? TextAttributes.INVERSE : 0}>
+            {charAtCursor}
+          </text>
+          <text fg={themeColors.primary}>{after}</text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components/ThemedComponents.tsx
+++ b/src/components/ThemedComponents.tsx
@@ -1,16 +1,23 @@
-import type { BoxProps, ScrollBoxProps, TextProps } from "@opentui/react"
-import { useThemeColors } from "../features/config/use_theme_colors"
+import type { BoxProps, ScrollBoxProps, TextProps } from "@opentui/react";
+import { useThemeColors } from "../features/config/use_theme_colors";
 
 export const Box = (props: BoxProps) => {
-  const theme = useThemeColors()
-  return <box backgroundColor={theme.backgroundColor} borderColor={theme.border} border={false} {...props} />
-}
+  const theme = useThemeColors();
+  return (
+    <box
+      backgroundColor={theme.backgroundColor}
+      borderColor={theme.border}
+      border={false}
+      {...props}
+    />
+  );
+};
 
 export const Text = ({ color = "text", ...props }: TextProps & { color?: "text" | "primary" }) => {
-  const theme = useThemeColors()
-  return <text fg={theme[color]} {...props} />
-}
+  const theme = useThemeColors();
+  return <text fg={theme[color]} {...props} />;
+};
 
 export const ScrollBox = (props: ScrollBoxProps) => {
-  return <scrollbox {...props} />
-}
+  return <scrollbox {...props} />;
+};

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -60,14 +60,10 @@ export const ISSUE_SYSTEM_MESSAGE = `
   {{issueTemplate.body}}
   """`;
 
-export const ISSUE_TEMPLATE_CANCELLED_MESSAGE =
-  "Issue template selection was cancelled.";
+export const ISSUE_TEMPLATE_CANCELLED_MESSAGE = "Issue template selection was cancelled.";
 
-export const ISSUE_SELECTION_CANCELLED_MESSAGE =
-  "Issue selection was cancelled.";
+export const ISSUE_SELECTION_CANCELLED_MESSAGE = "Issue selection was cancelled.";
 
-export const ISSUE_GENERATION_EMPTY_MESSAGE =
-  "No issue candidates were generated.";
+export const ISSUE_GENERATION_EMPTY_MESSAGE = "No issue candidates were generated.";
 
-export const SELECT_EMPTY_MESSAGE =
-  "No options available. Press Enter or Esc to go back.";
+export const SELECT_EMPTY_MESSAGE = "No options available. Press Enter or Esc to go back.";

--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -5,11 +5,11 @@ export const NORMAL_MODE_SHORTCUTS = [
   { key: "Ctrl+s", description: "Commit" },
 ] as const;
 
-export type NormalModeShortcuts = typeof NORMAL_MODE_SHORTCUTS[number];
+export type NormalModeShortcuts = (typeof NORMAL_MODE_SHORTCUTS)[number];
 
 export const AI_MODE_SHORTCUTS = [
   { key: "Tab", description: "Completion" },
   { key: "Esc", description: "Normal" },
 ] as const;
 
-export type AiModeShortcuts = typeof AI_MODE_SHORTCUTS[number];
+export type AiModeShortcuts = (typeof AI_MODE_SHORTCUTS)[number];

--- a/src/contexts/app_dependencies_context.tsx
+++ b/src/contexts/app_dependencies_context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, type ReactNode, useContext } from "react";
 import type { AppDependencies } from "../app/store.ts";
 
 const AppDependenciesContext = createContext<AppDependencies | null>(null);
@@ -11,9 +11,7 @@ export function AppDependenciesProvider({
   children: ReactNode;
 }) {
   return (
-    <AppDependenciesContext.Provider value={value}>
-      {children}
-    </AppDependenciesContext.Provider>
+    <AppDependenciesContext.Provider value={value}>{children}</AppDependenciesContext.Provider>
   );
 }
 

--- a/src/contexts/theme_mode_context.tsx
+++ b/src/contexts/theme_mode_context.tsx
@@ -1,23 +1,19 @@
 import type { ThemeMode } from "@opentui/core";
 import { useRenderer } from "@opentui/react";
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
 
-const ThemeModeContext = createContext<ThemeMode | null>(null);
+const THEME_MODE_CONTEXT_UNSET = Symbol("ThemeModeContext.unset");
+
+const ThemeModeContext = createContext<ThemeMode | null | typeof THEME_MODE_CONTEXT_UNSET>(
+  THEME_MODE_CONTEXT_UNSET,
+);
 
 export function ThemeModeProvider({ children }: { children: ReactNode }) {
   const renderer = useRenderer();
-  const [themeMode, setThemeMode] = useState<ThemeMode | null>(
-    renderer.themeMode ?? null,
-  );
+  const [themeMode, setThemeMode] = useState<ThemeMode | null>(renderer.themeMode);
 
   useEffect(() => {
-    setThemeMode(renderer.themeMode ?? null);
+    setThemeMode(renderer.themeMode);
 
     const handler = (mode: ThemeMode) => setThemeMode(mode);
     renderer.on("theme_mode", handler);
@@ -26,13 +22,13 @@ export function ThemeModeProvider({ children }: { children: ReactNode }) {
     };
   }, [renderer]);
 
-  return (
-    <ThemeModeContext.Provider value={themeMode}>
-      {children}
-    </ThemeModeContext.Provider>
-  );
+  return <ThemeModeContext.Provider value={themeMode}>{children}</ThemeModeContext.Provider>;
 }
 
 export function useThemeMode(): ThemeMode | null {
-  return useContext(ThemeModeContext);
+  const ctx = useContext(ThemeModeContext);
+  if (ctx === THEME_MODE_CONTEXT_UNSET) {
+    throw new Error("useThemeMode must be used within ThemeModeProvider");
+  }
+  return ctx;
 }

--- a/src/features/commit/commit_slice.ts
+++ b/src/features/commit/commit_slice.ts
@@ -14,9 +14,9 @@ export type CommitState =
   | { step: "loading" }
   | { step: "select"; messages: z.infer<typeof CommitSchema> }
   | {
-    step: "edit";
-    selectedMessage: z.infer<typeof CommitSchema>["commit_message"][number];
-  }
+      step: "edit";
+      selectedMessage: z.infer<typeof CommitSchema>["commit_message"][number];
+    }
   | { step: "commit"; commitMessage: string }
   | { step: "done" }
   | { step: "error"; message: string };
@@ -32,38 +32,30 @@ export const generateCommitMessages = createAppAsyncThunk<
   z.infer<typeof CommitSchema>,
   void,
   CommitThunkConfig
->(
-  "commit/generate",
-  async (_, { rejectWithValue, extra }) => {
-    const gitService = new GitService();
+>("commit/generate", async (_, { rejectWithValue, extra }) => {
+  const gitService = new GitService();
 
-    return fromPromiseWithMessage(gitService.diff.getGitDiffStaged())
-      .andThen((diff) => diff ? okAsync(diff) : errAsync("No diff found"))
-      .andThen((diff) =>
-        fromPromiseWithMessage(
-          AIService.create(extra.config, extra.credentials),
-        )
-          .andThen((aiService) =>
-            fromPromiseWithMessage(
-              aiService.generateStructuredOutput(
-                [
-                  { role: "system", content: COMMIT_SYSTEM_MESSAGE },
-                  { role: "user", content: diff },
-                ],
-                COMMIT_SYSTEM_MESSAGE,
-                CommitSchema,
-                (_usage) => {
-                },
-              ),
-            )
-          )
-      )
-      .andThen((result) =>
-        result ? okAsync(result) : errAsync("AI generation failed")
-      )
-      .match((result) => result, rejectWithValue);
-  },
-);
+  return fromPromiseWithMessage(gitService.diff.getGitDiffStaged())
+    .andThen((diff) => (diff ? okAsync(diff) : errAsync("No diff found")))
+    .andThen((diff) =>
+      fromPromiseWithMessage(AIService.create(extra.config, extra.credentials)).andThen(
+        (aiService) =>
+          fromPromiseWithMessage(
+            aiService.generateStructuredOutput(
+              [
+                { role: "system", content: COMMIT_SYSTEM_MESSAGE },
+                { role: "user", content: diff },
+              ],
+              COMMIT_SYSTEM_MESSAGE,
+              CommitSchema,
+              (_usage) => {},
+            ),
+          ),
+      ),
+    )
+    .andThen((result) => (result ? okAsync(result) : errAsync("AI generation failed")))
+    .match((result) => result, rejectWithValue);
+});
 
 export const editCommitMessage = createAppAsyncThunk<
   string,
@@ -75,14 +67,12 @@ export const editCommitMessage = createAppAsyncThunk<
     selectedMessage: z.infer<typeof CommitSchema>["commit_message"][number],
     { rejectWithValue },
   ) => {
-    const combinedMessage = [
-      selectedMessage.header,
-      selectedMessage.body,
-      selectedMessage.footer,
-    ].filter(Boolean).join("\n\n");
+    const combinedMessage = [selectedMessage.header, selectedMessage.body, selectedMessage.footer]
+      .filter(Boolean)
+      .join("\n\n");
 
     return fromPromiseWithMessage(editText(combinedMessage))
-      .andThen((edited) => edited.trim() ? okAsync(edited) : errAsync("Empty message"))
+      .andThen((edited) => (edited.trim() ? okAsync(edited) : errAsync("Empty message")))
       .match((edited) => edited, rejectWithValue);
   },
 );

--- a/src/features/commit/hook.ts
+++ b/src/features/commit/hook.ts
@@ -27,10 +27,10 @@ export function useCommitFlow() {
     selectCommitMessage: (
       message:
         | {
-          header: string;
-          body: string | null;
-          footer: string | null;
-        }
+            header: string;
+            body: string | null;
+            footer: string | null;
+          }
         | undefined,
     ) => {
       if (message) {

--- a/src/features/commit/ui.tsx
+++ b/src/features/commit/ui.tsx
@@ -6,19 +6,12 @@ import { useCommitFlow } from "./hook.ts";
 
 export function CommitUI() {
   const themeColors = useThemeColors();
-  const {
-    state,
-    generateCommitMessages,
-    selectCommitMessage,
-    commitMessage,
-    editCommitMessage,
-  } = useCommitFlow();
+  const { state, generateCommitMessages, selectCommitMessage, commitMessage, editCommitMessage } =
+    useCommitFlow();
 
   return (
     <Box>
-      {state.step === "loading" && (
-        <Spinner handleDataLoading={generateCommitMessages} />
-      )}
+      {state.step === "loading" && <Spinner handleDataLoading={generateCommitMessages} />}
       {state.step === "select" && (
         <Select
           message="Enter commit messages"
@@ -30,9 +23,7 @@ export function CommitUI() {
           onSelect={selectCommitMessage}
         />
       )}
-      {state.step === "edit" && (
-        <Spinner handleDataLoading={editCommitMessage} />
-      )}
+      {state.step === "edit" && <Spinner handleDataLoading={editCommitMessage} />}
       {state.step === "commit" && <Spinner handleDataLoading={commitMessage} />}
       {state.step === "done" && <Text>Done</Text>}
       {state.step === "error" && <Text fg={themeColors.error}>Error: {state.message}</Text>}

--- a/src/features/config/components/DetailPanel.tsx
+++ b/src/features/config/components/DetailPanel.tsx
@@ -10,47 +10,30 @@ interface DetailPanelProps {
 }
 
 export const DetailPanel = ({ item }: DetailPanelProps) => {
-  const itemPath = fullPath(item)
+  const itemPath = fullPath(item);
 
-  const mergedConfig = useAppSelector((state) => state.config.mergedConfig)
-  const defaultConfig = ConfigSchema.parse({})
-  const localConfig = useAppSelector((state) => state.config.localConfig)
-  const projectConfig = useAppSelector((state) => state.config.projectConfig)
-  const globalConfig = useAppSelector((state) => state.config.globalConfig)
+  const mergedConfig = useAppSelector((state) => state.config.mergedConfig);
+  const defaultConfig = ConfigSchema.parse({});
+  const localConfig = useAppSelector((state) => state.config.localConfig);
+  const projectConfig = useAppSelector((state) => state.config.projectConfig);
+  const globalConfig = useAppSelector((state) => state.config.globalConfig);
 
   return (
     <Box flexDirection="column" flexGrow={1}>
-      <Box
-        border
-        borderStyle="rounded"
-        paddingX={1}
-        flexGrow={1}
-        flexDirection="column"
-      >
-        <Text>
-          {`<${itemPath}>`}
-        </Text>
-        <Text>
-          {item.description}
-        </Text>
+      <Box border borderStyle="rounded" paddingX={1} flexGrow={1} flexDirection="column">
+        <Text>{`<${itemPath}>`}</Text>
+        <Text>{item.description}</Text>
         {item.isLeaf ? (
           <>
-            <Text>
-              current: {String(_.get(mergedConfig, itemPath) ?? "")}
-            </Text>
-            <Text>
-              default: {String(_.get(defaultConfig, itemPath) ?? "(not set)")}
-            </Text>
-            <Text>
-              local: {String(_.get(localConfig, itemPath) ?? "(not set)")}
-            </Text>
-            <Text>
-              project: {String(_.get(projectConfig, itemPath) ?? "(not set)")}
-            </Text>
-            <Text>
-              global: {String(_.get(globalConfig, itemPath) ?? "(not set)")}
-            </Text>
-          </>) : <Box />}
+            <Text>current: {String(_.get(mergedConfig, itemPath) ?? "")}</Text>
+            <Text>default: {String(_.get(defaultConfig, itemPath) ?? "(not set)")}</Text>
+            <Text>local: {String(_.get(localConfig, itemPath) ?? "(not set)")}</Text>
+            <Text>project: {String(_.get(projectConfig, itemPath) ?? "(not set)")}</Text>
+            <Text>global: {String(_.get(globalConfig, itemPath) ?? "(not set)")}</Text>
+          </>
+        ) : (
+          <Box />
+        )}
       </Box>
     </Box>
   );

--- a/src/features/config/components/TreeList.tsx
+++ b/src/features/config/components/TreeList.tsx
@@ -53,8 +53,6 @@ export const TreeList = ({ items, selectedPath, openPaths, onSelect, onToggle }:
                 event.preventDefault();
                 onSelect(path);
                 onToggle(path);
-                console.log(path);
-                console.error(path);
               }}
             >
               <Text

--- a/src/features/config/components/TreeList.tsx
+++ b/src/features/config/components/TreeList.tsx
@@ -1,10 +1,8 @@
-import { ScrollBoxRenderable, TextAttributes } from "@opentui/core";
+import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core";
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router";
 import { Box, ScrollBox, Text } from "../../../components/ThemedComponents.tsx";
 import type { FlatSchemaItem } from "../../../helpers/flat_schema.ts";
 import { fullPath } from "../../../helpers/flat_schema.ts";
-
 
 interface TreeListProps {
   items: FlatSchemaItem[];
@@ -14,20 +12,11 @@ interface TreeListProps {
   onToggle: (path: string) => void;
 }
 
-export const TreeList = (
-  {
-    items,
-    selectedPath,
-    openPaths,
-    onSelect,
-    onToggle,
-  }: TreeListProps,
-) => {
+export const TreeList = ({ items, selectedPath, openPaths, onSelect, onToggle }: TreeListProps) => {
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
-  const scrollboxRef = useRef<ScrollBoxRenderable | null>(null)
-  const height = (scrollboxRef.current?.height ?? 0) - 1
+  const scrollboxRef = useRef<ScrollBoxRenderable | null>(null);
+  const height = (scrollboxRef.current?.height ?? 0) - 1;
   useEffect(() => {
-
     const pos = scrollboxRef.current?.scrollTop ?? 0;
     const index = items.findIndex((item) => fullPath(item) === selectedPath);
     if (index > height + pos) {
@@ -35,17 +24,11 @@ export const TreeList = (
     } else if (index < pos) {
       scrollboxRef.current?.scrollTo(index);
     }
-  }, [selectedPath])
-
-  const params = useParams();
-  const allIds = params["*"]?.split("/") ?? [];
-
+  }, [selectedPath]);
 
   return (
     <Box flexDirection="column" width={30} height="100%">
-      <ScrollBox
-        ref={scrollboxRef}
-      >
+      <ScrollBox ref={scrollboxRef}>
         {items.map((item) => {
           const path = fullPath(item);
           const depth = item.parents.length;
@@ -64,16 +47,14 @@ export const TreeList = (
                 setHoveredPath(path);
               }}
               onMouseOut={() => {
-                setHoveredPath((currentPath) =>
-                  currentPath === path ? null : currentPath
-                );
+                setHoveredPath((currentPath) => (currentPath === path ? null : currentPath));
               }}
               onMouseDown={(event) => {
                 event.preventDefault();
                 onSelect(path);
                 onToggle(path);
-                console.log(path)
-                console.error(path)
+                console.log(path);
+                console.error(path);
               }}
             >
               <Text

--- a/src/features/config/config_page.tsx
+++ b/src/features/config/config_page.tsx
@@ -35,7 +35,7 @@ export const ConfigPage = ({ flattenConfigSchema }: ConfigPageProps) => {
   const openPaths = useAppSelector(selectConfigOpenPaths);
   const selectedItem = useAppSelector(selectConfigSelectedItem);
 
-  const theme = useThemeMode()
+  const theme = useThemeMode();
 
   useEffect(() => {
     dispatch(initializeConfigTree(flattenConfigSchema));
@@ -75,9 +75,7 @@ export const ConfigPage = ({ flattenConfigSchema }: ConfigPageProps) => {
 
   return (
     <Box flexDirection="column" height={size.height}>
-      <Text attributes={TextAttributes.BOLD}>
-        {`<Config> ${theme ?? ""}`}
-      </Text>
+      <Text attributes={TextAttributes.BOLD}>{`<Config> ${theme ?? ""}`}</Text>
       <SplitPane direction="horizontal">
         <TreeList
           items={filteredItems}
@@ -89,6 +87,6 @@ export const ConfigPage = ({ flattenConfigSchema }: ConfigPageProps) => {
         <DetailPanel item={selectedItem} />
       </SplitPane>
       <NotificationBar />
-    </Box >
+    </Box>
   );
 };

--- a/src/features/config/config_page_slice.test.ts
+++ b/src/features/config/config_page_slice.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { type FlatSchemaItem } from "../../helpers/flat_schema.ts";
+import type { FlatSchemaItem } from "../../helpers/flat_schema.ts";
 import {
   configUiReducer,
   initializeConfigTree,
@@ -35,10 +35,7 @@ test("toggleItem shows children only while the parent path is open", () => {
     items[2],
     items[3],
   ]);
-  expect(selectConfigFilteredItems.resultFunc(closed)).toEqual([
-    items[0],
-    items[3],
-  ]);
+  expect(selectConfigFilteredItems.resultFunc(closed)).toEqual([items[0], items[3]]);
 });
 
 test("moveDown uses the visible item order", () => {
@@ -49,10 +46,7 @@ test("moveDown uses the visible item order", () => {
 
   const visibleItems = selectConfigFilteredItems.resultFunc(state);
   const expectedSelectedPath = selectConfigSelectedPath.resultFunc(state);
-  const selectedIndex = selectConfigSelectedIndex.resultFunc(
-    visibleItems,
-    expectedSelectedPath,
-  );
+  const selectedIndex = selectConfigSelectedIndex.resultFunc(visibleItems, expectedSelectedPath);
 
   expect(expectedSelectedPath).toBe("ai.provider");
   expect(selectedIndex).toBe(2);

--- a/src/features/config/config_page_slice.ts
+++ b/src/features/config/config_page_slice.ts
@@ -1,10 +1,6 @@
-import {
-  createSelector,
-  createSlice,
-  type PayloadAction,
-} from "@reduxjs/toolkit";
+import { createSelector, createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { RootState } from "../../app/store.ts";
-import { fullPath, type FlatSchemaItem } from "../../helpers/flat_schema.ts";
+import { type FlatSchemaItem, fullPath } from "../../helpers/flat_schema.ts";
 
 interface ConfigState {
   items: FlatSchemaItem[];
@@ -19,16 +15,17 @@ const initialState: ConfigState = {
 };
 
 const isVisible = (item: FlatSchemaItem, openPaths: string[]) =>
-  item.parents.every((_, i) =>
-    openPaths.includes(item.parents.slice(0, i + 1).join("."))
-  );
+  item.parents.every((_, i) => openPaths.includes(item.parents.slice(0, i + 1).join(".")));
 
 const visibleItems = (state: ConfigState) =>
   state.items.filter((item) => isVisible(item, state.openPaths));
 
 const clampSelection = (state: ConfigState) => {
   const items = visibleItems(state);
-  if (items.length === 0) { state.selectedPath = null; return; }
+  if (items.length === 0) {
+    state.selectedPath = null;
+    return;
+  }
   if (!items.some((item) => fullPath(item) === state.selectedPath)) {
     state.selectedPath = items[0] ? fullPath(items[0]) : null;
   }
@@ -49,9 +46,7 @@ const configUiSlice = createSlice({
       if (!item || item.isLeaf) return;
 
       if (state.openPaths.includes(path)) {
-        state.openPaths = state.openPaths.filter(
-          (p) => p !== path && !p.startsWith(`${path}.`)
-        );
+        state.openPaths = state.openPaths.filter((p) => p !== path && !p.startsWith(`${path}.`));
       } else {
         state.openPaths.push(path);
       }
@@ -75,10 +70,7 @@ const configUiSlice = createSlice({
 
 const selectConfigState = (state: RootState) => state.configUi;
 
-export const selectConfigFilteredItems = createSelector(
-  [selectConfigState],
-  visibleItems,
-);
+export const selectConfigFilteredItems = createSelector([selectConfigState], visibleItems);
 
 export const selectConfigOpenPaths = createSelector(
   [selectConfigState],
@@ -92,7 +84,11 @@ export const selectConfigSelectedPath = createSelector(
 
 export const selectConfigSelectedIndex = createSelector(
   [selectConfigFilteredItems, selectConfigSelectedPath],
-  (items, path) => Math.max(0, items.findIndex((item) => fullPath(item) === path)),
+  (items, path) =>
+    Math.max(
+      0,
+      items.findIndex((item) => fullPath(item) === path),
+    ),
 );
 
 export const selectConfigSelectedItem = createSelector(
@@ -100,11 +96,6 @@ export const selectConfigSelectedItem = createSelector(
   (items, i) => items[i] ?? null,
 );
 
-export const {
-  initializeConfigTree,
-  moveDown,
-  moveUp,
-  selectItem,
-  toggleItem,
-} = configUiSlice.actions;
+export const { initializeConfigTree, moveDown, moveUp, selectItem, toggleItem } =
+  configUiSlice.actions;
 export const configUiReducer = configUiSlice.reducer;

--- a/src/features/config/config_slice.ts
+++ b/src/features/config/config_slice.ts
@@ -2,7 +2,7 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { createAppAsyncThunk } from "../../app/hooks.ts";
 import { fromPromiseWithMessage } from "../../helpers/error/neverthrow.ts";
 import type { ConfigScope } from "../../services/config/config_file.ts";
-import { ConfigSchema, type Config } from "../../services/config/schema/config_schema.ts";
+import { type Config, ConfigSchema } from "../../services/config/schema/config_schema.ts";
 import type { GlobalConfig } from "../../services/config/schema/global_config_schema.ts";
 import type { LocalConfig } from "../../services/config/schema/local_config_schema.ts";
 import type { ProjectConfig } from "../../services/config/schema/project_config_schema.ts";
@@ -41,10 +41,9 @@ export const setConfig = createAppAsyncThunk<
     value: PathValue<Config, NestedKeys<Config>>;
   },
   SetConfigThunkConfig
->(
-  "Config/setGlobalConfig",
-  async ({ scope, key, value }, { extra, rejectWithValue }) => {
-    return fromPromiseWithMessage((async () => {
+>("Config/setGlobalConfig", async ({ scope, key, value }, { extra, rejectWithValue }) => {
+  return fromPromiseWithMessage(
+    (async () => {
       await extra.config.saveConfig(scope, key, value);
       const mergedConfig = await extra.config.getMergedConfig();
 
@@ -56,9 +55,9 @@ export const setConfig = createAppAsyncThunk<
         case "project":
           return { projectConfig: await extra.config.getProjectConfig(), mergedConfig };
       }
-    })()).match((result) => result, rejectWithValue);
-  },
-);
+    })(),
+  ).match((result) => result, rejectWithValue);
+});
 
 const configSlice = createSlice({
   name: "Config",

--- a/src/features/config/layout.tsx
+++ b/src/features/config/layout.tsx
@@ -1,7 +1,5 @@
 import { Outlet } from "react-router";
 
 export const ConfigLayout = () => {
-  return (
-    <Outlet />
-  );
+  return <Outlet />;
 };

--- a/src/features/config/use_theme_colors.test.tsx
+++ b/src/features/config/use_theme_colors.test.tsx
@@ -1,10 +1,16 @@
-import { testRender } from "@opentui/react/test-utils";
 import { expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
 import { Provider } from "react-redux";
 import { createAppStore } from "../../app/store.ts";
+import { ThemeModeProvider } from "../../contexts/theme_mode_context.tsx";
 import { ConfigSchema } from "../../services/config/schema/config_schema.ts";
-import { DARK_THEME_COLORS, DEFAULT_COLOR_CONFIG, LIGHT_THEME_COLORS, SOLID_LIGHT_THEME_COLORS } from "../../services/config/schema/fields/theme_schema.ts";
+import {
+  DARK_THEME_COLORS,
+  DEFAULT_COLOR_CONFIG,
+  LIGHT_THEME_COLORS,
+  SOLID_LIGHT_THEME_COLORS,
+} from "../../services/config/schema/fields/theme_schema.ts";
 import { resolveThemeColors, useThemeColors } from "./use_theme_colors.ts";
 
 test("resolveThemeColors reflects detected light mode for AdaptiveDark", () => {
@@ -24,9 +30,7 @@ test("resolveThemeColors returns backgroundColor for SolidLight", () => {
 });
 
 test("resolveThemeColors preserves custom colors including undefined background", () => {
-  expect(
-    resolveThemeColors("Custom", "dark", DEFAULT_COLOR_CONFIG),
-  ).toEqual(DEFAULT_COLOR_CONFIG);
+  expect(resolveThemeColors("Custom", "dark", DEFAULT_COLOR_CONFIG)).toEqual(DEFAULT_COLOR_CONFIG);
 });
 
 test("resolveThemeColors falls back to default custom colors", () => {
@@ -38,9 +42,7 @@ function ThemeColorsProbe() {
 
   return (
     <box>
-      <text>
-        {`colors:${colors.primary}`}
-      </text>
+      <text>{`colors:${colors.primary}`}</text>
     </box>
   );
 }
@@ -51,11 +53,13 @@ test("useThemeColors reads colors from preloaded config", async () => {
       mergedConfig: ConfigSchema.parse({
         theme: { mode: "SolidLight" },
       }),
-    }
+    },
   });
   const tui = await testRender(
     <Provider store={store}>
-      <ThemeColorsProbe />
+      <ThemeModeProvider>
+        <ThemeColorsProbe />
+      </ThemeModeProvider>
     </Provider>,
     {
       width: 80,

--- a/src/features/config/use_theme_colors.ts
+++ b/src/features/config/use_theme_colors.ts
@@ -4,7 +4,13 @@ import { useAppSelector } from "../../app/hooks.ts";
 import type { RootState } from "../../app/store.ts";
 import { useThemeMode } from "../../contexts/theme_mode_context.tsx";
 import type { ColorConfig, ThemeConfig } from "../../services/config/schema/fields/theme_schema.ts";
-import { DARK_THEME_COLORS, DEFAULT_COLOR_CONFIG, LIGHT_THEME_COLORS, SOLID_DARK_THEME_COLORS, SOLID_LIGHT_THEME_COLORS } from "../../services/config/schema/fields/theme_schema.ts";
+import {
+  DARK_THEME_COLORS,
+  DEFAULT_COLOR_CONFIG,
+  LIGHT_THEME_COLORS,
+  SOLID_DARK_THEME_COLORS,
+  SOLID_LIGHT_THEME_COLORS,
+} from "../../services/config/schema/fields/theme_schema.ts";
 
 export function resolveThemeColors(
   mode: ThemeConfig["mode"],
@@ -13,13 +19,9 @@ export function resolveThemeColors(
 ): ColorConfig {
   switch (mode) {
     case "AdaptiveDark":
-      return themeMode === "light"
-        ? LIGHT_THEME_COLORS
-        : DARK_THEME_COLORS;
+      return themeMode === "light" ? LIGHT_THEME_COLORS : DARK_THEME_COLORS;
     case "AdaptiveLight":
-      return themeMode === "dark"
-        ? DARK_THEME_COLORS
-        : LIGHT_THEME_COLORS;
+      return themeMode === "dark" ? DARK_THEME_COLORS : LIGHT_THEME_COLORS;
     case "GenericDark":
       return DARK_THEME_COLORS;
     case "GenericLight":
@@ -34,7 +36,7 @@ export function resolveThemeColors(
 }
 
 export function useThemeColors(): ColorConfig {
-  const config = useAppSelector(((state: RootState) => state.config.mergedConfig));
+  const config = useAppSelector((state: RootState) => state.config.mergedConfig);
   const themeMode = useThemeMode();
 
   if (!config) {

--- a/src/features/home/ui.tsx
+++ b/src/features/home/ui.tsx
@@ -1,9 +1,5 @@
-import { Box } from "../../components/ThemedComponents"
+import { Box } from "../../components/ThemedComponents";
 
 export const HomeUI = () => {
-  return (
-    <Box>
-
-    </Box>
-  )
-}
+  return <Box></Box>;
+};

--- a/src/features/init/done_page.tsx
+++ b/src/features/init/done_page.tsx
@@ -1,13 +1,9 @@
 import { TextAttributes } from "@opentui/core";
 import { useKeyboard, useRenderer } from "@opentui/react";
-import {
-  useLocation,
-  useNavigate,
-  useSearchParams
-} from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { Box, Text } from "../../components/ThemedComponents.tsx";
-import { useThemeColors } from "../config/use_theme_colors.ts";
 import { isCtrlC, isEnter } from "../../helpers/opentui/key.ts";
+import { useThemeColors } from "../config/use_theme_colors.ts";
 
 export function DonePage() {
   const [searchParams] = useSearchParams();

--- a/src/features/init/layout.tsx
+++ b/src/features/init/layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from "react-router";
 import { useAppSelector } from "../../app/hooks.ts";
-import type { Config } from "../../services/config/schema/config_schema.ts";
 import { Box } from "../../components/ThemedComponents.tsx";
+import type { Config } from "../../services/config/schema/config_schema.ts";
 
 export interface InitOutletContext {
   config: Config;

--- a/src/features/init/profile_page.tsx
+++ b/src/features/init/profile_page.tsx
@@ -1,5 +1,5 @@
-import { Select } from "../../components/Select.tsx";
 import { useLocation, useNavigate } from "react-router";
+import { Select } from "../../components/Select.tsx";
 
 const profileChoices = [
   {

--- a/src/features/init/review_page.tsx
+++ b/src/features/init/review_page.tsx
@@ -1,12 +1,8 @@
 import { TextAttributes } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
-import {
-  useLocation,
-  useNavigate,
-  useSearchParams
-} from "react-router";
-import { isEnter } from "../../helpers/opentui/key.ts";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { Box, Text } from "../../components/ThemedComponents.tsx";
+import { isEnter } from "../../helpers/opentui/key.ts";
 
 export function ReviewPage() {
   const [searchParams] = useSearchParams();

--- a/src/features/init/theme_page.tsx
+++ b/src/features/init/theme_page.tsx
@@ -11,11 +11,7 @@ import type { InitOutletContext } from "./layout.tsx";
 export function ThemePage() {
   const { config } = useOutletContext<InitOutletContext>();
   const themeMode = useThemeMode();
-  const themeColors = resolveThemeColors(
-    config.theme.mode,
-    themeMode,
-    config.theme.color,
-  );
+  const themeColors = resolveThemeColors(config.theme.mode, themeMode, config.theme.color);
   const themes = ThemeConfigSchema.shape.mode.options;
   const [selected, setSelected] = useState(themes.indexOf(config.theme.mode));
 
@@ -29,22 +25,27 @@ export function ThemePage() {
 
   return (
     <Box flexDirection="column">
-      <Text fg={themeColors.primary} attributes={TextAttributes.BOLD}>Select a theme</Text>
+      <Text fg={themeColors.primary} attributes={TextAttributes.BOLD}>
+        Select a theme
+      </Text>
       <Text fg={themeColors.text}>
         current: {config.theme.mode} / detected: {themeMode ?? "unsupported"}
       </Text>
       <Box flexDirection="row">
         <Box flexDirection="column" width={30}>
           {themes.map((theme, index) => (
-            <Box key={theme} flexDirection="row" onMouseDown={() => {
-              setSelected(index)
-            }}>
+            <Box
+              key={theme}
+              flexDirection="row"
+              onMouseDown={() => {
+                setSelected(index);
+              }}
+            >
               <Text fg={themeColors.primary}>{index === selected ? "→ " : "  "}</Text>
 
               <Text fg={index === selected ? themeColors.primary : themeColors.text}>
                 {theme} {theme === config.theme.mode ? "(current)" : ""}
               </Text>
-
             </Box>
           ))}
         </Box>

--- a/src/features/issue/domain/parser.test.ts
+++ b/src/features/issue/domain/parser.test.ts
@@ -3,10 +3,8 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
-import {
-  parseMarkdownIssueTemplate,
-  stringifyMarkdownIssue,
-} from "./parser.ts";
+
+import { parseMarkdownIssueTemplate, stringifyMarkdownIssue } from "./parser.ts";
 
 test("parseMarkdownIssueTemplate", () => {
   const markdown = `---

--- a/src/features/issue/domain/parser.ts
+++ b/src/features/issue/domain/parser.ts
@@ -1,9 +1,7 @@
 import { parse, stringify } from "yaml";
 import type { Issue, IssueTemplate } from "../../../type.ts";
 
-export function parseMarkdownIssueTemplate(
-  markdown: string,
-): IssueTemplate {
+export function parseMarkdownIssueTemplate(markdown: string): IssueTemplate {
   const { attributes, body } = parseFrontMatter(markdown);
   const attrs = attributes as Partial<IssueTemplate>;
 
@@ -15,9 +13,7 @@ export function parseMarkdownIssueTemplate(
   };
 }
 
-export function stringifyMarkdownIssue(
-  issue: Issue,
-): string {
+export function stringifyMarkdownIssue(issue: Issue): string {
   const yamlBlock = stringify(
     {
       title: issue.title,

--- a/src/features/issue/domain/template_paths.ts
+++ b/src/features/issue/domain/template_paths.ts
@@ -1,9 +1,7 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-export async function getIssueTemplatePath(): Promise<
-  { markdown: string[]; yaml: string[] }
-> {
+export async function getIssueTemplatePath(): Promise<{ markdown: string[]; yaml: string[] }> {
   const markdownTemplatePath = [];
   const yamlTemplatePath = [];
   const templateDir = join(process.cwd(), ".github", "ISSUE_TEMPLATE");

--- a/src/features/issue/hook.test.ts
+++ b/src/features/issue/hook.test.ts
@@ -16,29 +16,27 @@ test("shouldCloseIssueFlow only closes done and error steps", () => {
 });
 
 test("getTemplateSelectionError returns a cancellation message when missing", () => {
-  expect(getTemplateSelectionError(undefined)).toBe(
-    ISSUE_TEMPLATE_CANCELLED_MESSAGE,
-  );
-  expect(getTemplateSelectionError({
-    name: "Feature",
-    about: "Feature request",
-    title: "Title",
-    body: "Body",
-  })).toBeUndefined();
+  expect(getTemplateSelectionError(undefined)).toBe(ISSUE_TEMPLATE_CANCELLED_MESSAGE);
+  expect(
+    getTemplateSelectionError({
+      name: "Feature",
+      about: "Feature request",
+      title: "Title",
+      body: "Body",
+    }),
+  ).toBeUndefined();
 });
 
 test("getGeneratedIssuesError validates generated issue candidates", () => {
-  expect(getGeneratedIssuesError({ issue: [] })).toBe(
-    ISSUE_GENERATION_EMPTY_MESSAGE,
-  );
-  expect(getGeneratedIssuesError({
-    issue: [{ title: "Title", body: "Body" }],
-  })).toBeUndefined();
+  expect(getGeneratedIssuesError({ issue: [] })).toBe(ISSUE_GENERATION_EMPTY_MESSAGE);
+  expect(
+    getGeneratedIssuesError({
+      issue: [{ title: "Title", body: "Body" }],
+    }),
+  ).toBeUndefined();
 });
 
 test("getIssueSelectionError returns a cancellation message when missing", () => {
-  expect(getIssueSelectionError(undefined)).toBe(
-    ISSUE_SELECTION_CANCELLED_MESSAGE,
-  );
+  expect(getIssueSelectionError(undefined)).toBe(ISSUE_SELECTION_CANCELLED_MESSAGE);
   expect(getIssueSelectionError({ title: "Title", body: "Body" })).toBeUndefined();
 });

--- a/src/features/issue/hook.ts
+++ b/src/features/issue/hook.ts
@@ -9,6 +9,7 @@ import {
 } from "../../constants/message.ts";
 import type { IssueSchema } from "../../schema.ts";
 import type { Issue, IssueTemplate } from "../../type.ts";
+import type { IssueState } from "./issue_slice.ts";
 import {
   createIssue,
   editIssue,
@@ -19,7 +20,6 @@ import {
   setGeneratedIssues,
   submitOverview,
 } from "./issue_slice.ts";
-import type { IssueState } from "./issue_slice.ts";
 
 export {
   ISSUE_GENERATION_EMPTY_MESSAGE,
@@ -36,9 +36,7 @@ export function getTemplateSelectionError(template: IssueTemplate | undefined) {
 }
 
 export function getGeneratedIssuesError(result: z.infer<typeof IssueSchema>) {
-  return result && result.issue.length > 0
-    ? undefined
-    : ISSUE_GENERATION_EMPTY_MESSAGE;
+  return result && result.issue.length > 0 ? undefined : ISSUE_GENERATION_EMPTY_MESSAGE;
 }
 
 export function getIssueSelectionError(issue: Issue | undefined) {
@@ -64,39 +62,51 @@ export function useIssueFlow() {
     await dispatch(loadTemplates());
   }, [dispatch]);
 
-  const selectTemplateHandler = useCallback((template: IssueTemplate | undefined) => {
-    const errorMessage = getTemplateSelectionError(template);
-    if (!errorMessage && template) {
-      dispatch(selectTemplate(template));
-      return;
-    }
+  const selectTemplateHandler = useCallback(
+    (template: IssueTemplate | undefined) => {
+      const errorMessage = getTemplateSelectionError(template);
+      if (!errorMessage && template) {
+        dispatch(selectTemplate(template));
+        return;
+      }
 
-    dispatch(setError(errorMessage ?? ISSUE_TEMPLATE_CANCELLED_MESSAGE));
-  }, [dispatch]);
+      dispatch(setError(errorMessage ?? ISSUE_TEMPLATE_CANCELLED_MESSAGE));
+    },
+    [dispatch],
+  );
 
-  const submitOverviewHandler = useCallback((overview: string) => {
-    dispatch(submitOverview(overview));
-  }, [dispatch]);
+  const submitOverviewHandler = useCallback(
+    (overview: string) => {
+      dispatch(submitOverview(overview));
+    },
+    [dispatch],
+  );
 
-  const handleAgentDone = useCallback((result: z.infer<typeof IssueSchema>) => {
-    const errorMessage = getGeneratedIssuesError(result);
-    if (!errorMessage) {
-      dispatch(setGeneratedIssues(result));
-      return;
-    }
+  const handleAgentDone = useCallback(
+    (result: z.infer<typeof IssueSchema>) => {
+      const errorMessage = getGeneratedIssuesError(result);
+      if (!errorMessage) {
+        dispatch(setGeneratedIssues(result));
+        return;
+      }
 
-    dispatch(setError(errorMessage));
-  }, [dispatch]);
+      dispatch(setError(errorMessage));
+    },
+    [dispatch],
+  );
 
-  const selectIssueHandler = useCallback((issue: Issue | undefined) => {
-    const errorMessage = getIssueSelectionError(issue);
-    if (!errorMessage && issue) {
-      dispatch(selectIssue(issue));
-      return;
-    }
+  const selectIssueHandler = useCallback(
+    (issue: Issue | undefined) => {
+      const errorMessage = getIssueSelectionError(issue);
+      if (!errorMessage && issue) {
+        dispatch(selectIssue(issue));
+        return;
+      }
 
-    dispatch(setError(errorMessage ?? ISSUE_SELECTION_CANCELLED_MESSAGE));
-  }, [dispatch]);
+      dispatch(setError(errorMessage ?? ISSUE_SELECTION_CANCELLED_MESSAGE));
+    },
+    [dispatch],
+  );
 
   const editIssueHandler = useCallback(async () => {
     if (step === "edit_issue" && selectedIssue) {

--- a/src/features/issue/issue_slice.ts
+++ b/src/features/issue/issue_slice.ts
@@ -1,19 +1,16 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import {
-  errAsync,
-  okAsync,
-} from "neverthrow";
+import { errAsync, okAsync } from "neverthrow";
 import type z from "zod";
 import { createAppAsyncThunk } from "../../app/hooks.ts";
-import {
-  fromPromiseWithMessage,
-  fromThrowableWithMessage,
-} from "../../helpers/error/neverthrow.ts";
 import {
   parseMarkdownIssueTemplate,
   stringifyMarkdownIssue,
 } from "../../features/issue/domain/parser.ts";
 import { getIssueTemplatePath } from "../../features/issue/domain/template_paths.ts";
+import {
+  fromPromiseWithMessage,
+  fromThrowableWithMessage,
+} from "../../helpers/error/neverthrow.ts";
 import type { IssueSchema } from "../../schema.ts";
 import { editText } from "../../services/editor/edit_text.ts";
 import { createIssue as createIssueService } from "../../services/github/issue.ts";
@@ -42,11 +39,7 @@ type IssueThunkConfig = {
 const parseIssueTemplate = fromThrowableWithMessage(parseMarkdownIssueTemplate);
 
 // Async thunks
-export const loadTemplates = createAppAsyncThunk<
-  IssueTemplate[],
-  void,
-  IssueThunkConfig
->(
+export const loadTemplates = createAppAsyncThunk<IssueTemplate[], void, IssueThunkConfig>(
   "issue/loadTemplates",
   async (_, { rejectWithValue }) => {
     return fromPromiseWithMessage(getIssueTemplatePath())
@@ -54,15 +47,13 @@ export const loadTemplates = createAppAsyncThunk<
         fromPromiseWithMessage(
           Promise.all(
             issueTemplatePath.markdown.map(async (markdownPath) =>
-              parseMarkdownIssueTemplate(await Bun.file(markdownPath).text())
+              parseMarkdownIssueTemplate(await Bun.file(markdownPath).text()),
             ),
           ),
-        )
+        ),
       )
       .andThen((issueTemplates) =>
-        issueTemplates.length === 0
-          ? errAsync("No templates found")
-          : okAsync(issueTemplates)
+        issueTemplates.length === 0 ? errAsync("No templates found") : okAsync(issueTemplates),
       )
       .match((issueTemplates) => issueTemplates, rejectWithValue);
   },
@@ -162,13 +153,7 @@ const issueSlice = createSlice({
   },
 });
 
-export const {
-  selectTemplate,
-  submitOverview,
-  setGeneratedIssues,
-  selectIssue,
-  setError,
-  reset,
-} = issueSlice.actions;
+export const { selectTemplate, submitOverview, setGeneratedIssues, selectIssue, setError, reset } =
+  issueSlice.actions;
 
 export const issueReducer = issueSlice.reducer;

--- a/src/features/issue/ui.test.ts
+++ b/src/features/issue/ui.test.ts
@@ -7,40 +7,50 @@ import {
 } from "./ui.tsx";
 
 test("buildIssueTemplateChoices maps templates for Select", () => {
-  expect(buildIssueTemplateChoices([{
-    name: "Bug Report",
-    about: "Report a bug",
-    title: "Bug",
-    body: "Body",
-  }])).toEqual([{
-    name: "Bug Report",
-    value: {
+  expect(
+    buildIssueTemplateChoices([
+      {
+        name: "Bug Report",
+        about: "Report a bug",
+        title: "Bug",
+        body: "Body",
+      },
+    ]),
+  ).toEqual([
+    {
       name: "Bug Report",
-      about: "Report a bug",
-      title: "Bug",
-      body: "Body",
+      value: {
+        name: "Bug Report",
+        about: "Report a bug",
+        title: "Bug",
+        body: "Body",
+      },
+      description: "Report a bug",
     },
-    description: "Report a bug",
-  }]);
+  ]);
 });
 
 test("buildGeneratedIssueChoices maps issues for Carousel", () => {
-  expect(buildGeneratedIssueChoices([{
-    title: "Generated title",
-    body: "Generated body",
-  }])).toEqual([{
-    name: "Generated title",
-    value: {
-      title: "Generated title",
-      body: "Generated body",
+  expect(
+    buildGeneratedIssueChoices([
+      {
+        title: "Generated title",
+        body: "Generated body",
+      },
+    ]),
+  ).toEqual([
+    {
+      name: "Generated title",
+      value: {
+        title: "Generated title",
+        body: "Generated body",
+      },
+      description: "Generated body",
     },
-    description: "Generated body",
-  }]);
+  ]);
 });
 
 test("issue UI text helpers format success and error messages", () => {
-  expect(getIssueCreatedText("https://example.com")).toBe(
-    "Issue created: https://example.com",
-  );
+  expect(getIssueCreatedText("https://example.com")).toBe("Issue created: https://example.com");
   expect(getIssueErrorText("Boom")).toBe("Error: Boom");
 });

--- a/src/features/issue/ui.tsx
+++ b/src/features/issue/ui.tsx
@@ -5,8 +5,8 @@ import { Spinner } from "../../components/Spinner.tsx";
 import { TextInput } from "../../components/TextInput.tsx";
 import { Box, Text } from "../../components/ThemedComponents.tsx";
 import { ISSUE_SYSTEM_MESSAGE } from "../../constants/message.ts";
-import { useThemeColors } from "../config/use_theme_colors.ts";
 import type { Issue as IssueEntity, IssueTemplate } from "../../type.ts";
+import { useThemeColors } from "../config/use_theme_colors.ts";
 import { useIssueFlow } from "./hook.ts";
 
 export function buildIssueTemplateChoices(templates: IssueTemplate[]) {
@@ -49,9 +49,7 @@ export function IssueUI() {
 
   return (
     <Box flexDirection="column">
-      {state.step === "loading_templates" && (
-        <Spinner handleDataLoading={loadTemplates} />
-      )}
+      {state.step === "loading_templates" && <Spinner handleDataLoading={loadTemplates} />}
       {state.step === "select_template" && (
         <Select
           message="Select an issue template"
@@ -60,24 +58,21 @@ export function IssueUI() {
         />
       )}
       {state.step === "input_overview" && (
-        <TextInput
-          label="? Enter the issue overview ›"
-          onSubmit={submitOverview}
-        />
+        <TextInput label="? Enter the issue overview ›" onSubmit={submitOverview} />
       )}
       {state.step === "generating" && (
         <AgentLoop
           initialMessages={[
             {
               role: "system",
-              content: ISSUE_SYSTEM_MESSAGE
-                .replace(/{{issueTemplate.title}}/g, state.template.title)
-                .replace(/{{issueTemplate.body}}/g, state.template.body),
+              content: ISSUE_SYSTEM_MESSAGE.replace(
+                /{{issueTemplate.title}}/g,
+                state.template.title,
+              ).replace(/{{issueTemplate.body}}/g, state.template.body),
             },
             {
               role: "user",
-              content:
-                `Here is the issue overview provided by the user:\n\n${state.overview}`,
+              content: `Here is the issue overview provided by the user:\n\n${state.overview}`,
             },
           ]}
           onDone={handleAgentDone}

--- a/src/features/notifications/NotificationBar.tsx
+++ b/src/features/notifications/NotificationBar.tsx
@@ -2,10 +2,7 @@ import { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "../../app/hooks.ts";
 import { Box } from "../../components/ThemedComponents.tsx";
 import { useThemeColors } from "../config/use_theme_colors.ts";
-import {
-  removeNotification,
-  type NotificationLevel,
-} from "./notifications_slice.ts";
+import { type NotificationLevel, removeNotification } from "./notifications_slice.ts";
 
 const AUTO_DISMISS_MS = 4000;
 
@@ -35,10 +32,14 @@ export const NotificationBar = () => {
 
   const colorFor = (level: NotificationLevel): string => {
     switch (level) {
-      case "info": return theme.info;
-      case "success": return theme.success;
-      case "warn": return theme.warning;
-      case "error": return theme.error;
+      case "info":
+        return theme.info;
+      case "success":
+        return theme.success;
+      case "warn":
+        return theme.warning;
+      case "error":
+        return theme.error;
     }
   };
 

--- a/src/features/notifications/notifications_slice.ts
+++ b/src/features/notifications/notifications_slice.ts
@@ -22,10 +22,7 @@ const notificationsSlice = createSlice({
   name: "notifications",
   initialState,
   reducers: {
-    addNotification: (
-      state,
-      action: PayloadAction<Omit<Notification, "id">>,
-    ) => {
+    addNotification: (state, action: PayloadAction<Omit<Notification, "id">>) => {
       state.items.push({ id: String(nextId++), ...action.payload });
     },
     removeNotification: (state, action: PayloadAction<string>) => {

--- a/src/features/notifications/use_notify.ts
+++ b/src/features/notifications/use_notify.ts
@@ -1,8 +1,5 @@
 import { useAppDispatch } from "../../app/hooks.ts";
-import {
-  addNotification,
-  type NotificationLevel,
-} from "./notifications_slice.ts";
+import { addNotification, type NotificationLevel } from "./notifications_slice.ts";
 
 export function useNotify() {
   const dispatch = useAppDispatch();

--- a/src/helpers/collections/cycle_zip.test.ts
+++ b/src/helpers/collections/cycle_zip.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
+
 import { cycleZip } from "./cycle_zip.ts";
 
 test("cycleZip - same length arrays", () => {
@@ -153,7 +154,11 @@ test("cycleZip - verify cycling behavior", () => {
 
 test("cycleZip - objects and arrays", () => {
   const arr1 = [{ id: 1 }, { id: 2 }];
-  const arr2 = [[1, 2], [3, 4], [5, 6]];
+  const arr2 = [
+    [1, 2],
+    [3, 4],
+    [5, 6],
+  ];
   const result = cycleZip(arr1, arr2);
 
   // LCM(2, 3) = 6

--- a/src/helpers/flat_schema.ts
+++ b/src/helpers/flat_schema.ts
@@ -19,9 +19,7 @@ export function flatSchema(
   schema: z.ZodDefault<z.ZodObject> | z.ZodObject,
   parents: string[] = [],
 ): FlatSchemaItem[] {
-  const shape = schema instanceof z.ZodDefault
-    ? schema.unwrap().shape
-    : schema.shape;
+  const shape = schema instanceof z.ZodDefault ? schema.unwrap().shape : schema.shape;
 
   return Object.entries(shape).flatMap(([key, field]) => {
     const item: FlatSchemaItem = {
@@ -34,10 +32,7 @@ export function flatSchema(
     if (field instanceof z.ZodDefault || field instanceof z.ZodObject) {
       return [
         item,
-        ...flatSchema(field as z.ZodDefault<z.ZodObject> | z.ZodObject, [
-          ...parents,
-          key,
-        ]),
+        ...flatSchema(field as z.ZodDefault<z.ZodObject> | z.ZodObject, [...parents, key]),
       ];
     }
     return [item];

--- a/src/helpers/redux/text_field_reducers.ts
+++ b/src/helpers/redux/text_field_reducers.ts
@@ -12,9 +12,7 @@ export type TextFieldState = {
  * Inserts a character at the current cursor position
  */
 export function typeChar(state: TextFieldState, char: string): void {
-  state.value = state.value.slice(0, state.cursor) +
-    char +
-    state.value.slice(state.cursor);
+  state.value = state.value.slice(0, state.cursor) + char + state.value.slice(state.cursor);
   state.cursor += char.length;
 }
 
@@ -23,8 +21,7 @@ export function typeChar(state: TextFieldState, char: string): void {
  */
 export function deleteChar(state: TextFieldState): void {
   if (state.cursor === 0) return;
-  state.value = state.value.slice(0, state.cursor - 1) +
-    state.value.slice(state.cursor);
+  state.value = state.value.slice(0, state.cursor - 1) + state.value.slice(state.cursor);
   state.cursor -= 1;
 }
 

--- a/src/helpers/send_to_terminal.ts
+++ b/src/helpers/send_to_terminal.ts
@@ -5,11 +5,20 @@ export function sendToTerminal(sequence: string): void {
   const isWindows = platform() === "win32";
   const ttyPath = isWindows ? "CONOUT$" : "/dev/tty";
 
+  let fd: number | undefined;
+
   try {
-    const fd = openSync(ttyPath, "w");
+    fd = openSync(ttyPath, "w");
     writeSync(fd, sequence);
-    closeSync(fd);
   } catch (_err) {
     process.stderr.write(sequence);
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore close errors
+      }
+    }
   }
 }

--- a/src/helpers/send_to_terminal.ts
+++ b/src/helpers/send_to_terminal.ts
@@ -1,15 +1,15 @@
-import { closeSync, openSync, writeSync } from 'node:fs';
-import { platform } from 'node:os';
+import { closeSync, openSync, writeSync } from "node:fs";
+import { platform } from "node:os";
 
-function sendToTerminal(sequence: string): void {
-  const isWindows = platform() === 'win32';
-  const ttyPath = isWindows ? 'CONOUT$' : '/dev/tty';
+export function sendToTerminal(sequence: string): void {
+  const isWindows = platform() === "win32";
+  const ttyPath = isWindows ? "CONOUT$" : "/dev/tty";
 
   try {
-    const fd = openSync(ttyPath, 'w');
+    const fd = openSync(ttyPath, "w");
     writeSync(fd, sequence);
     closeSync(fd);
-  } catch (err) {
+  } catch (_err) {
     process.stderr.write(sequence);
   }
 }

--- a/src/helpers/text/display_width.test.ts
+++ b/src/helpers/text/display_width.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
+
 import { getDisplayWidth } from "./display_width.ts";
 
 test("getDisplayWidth - ASCII characters", () => {

--- a/src/helpers/text/word_wrap.test.ts
+++ b/src/helpers/text/word_wrap.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
+
 import { wrapTextByWords } from "./word_wrap.ts";
 
 test("wrapTextByWords - fits in single line", () => {
@@ -92,10 +93,7 @@ test("wrapTextByWords - empty line in middle", () => {
 });
 
 test("wrapTextByWords - multiple paragraphs with wrapping", () => {
-  const result = wrapTextByWords(
-    "fix: add user authentication\nfeat: new feature",
-    20,
-  );
+  const result = wrapTextByWords("fix: add user authentication\nfeat: new feature", 20);
 
   // First paragraph wraps into 2 lines, second paragraph is 1 line (17 chars, fits in 20)
   assertEquals(result.length, 3);

--- a/src/helpers/text/word_wrap.ts
+++ b/src/helpers/text/word_wrap.ts
@@ -19,10 +19,7 @@ export type WrappedLine = {
  * //   { text: "feature", start: 29 }
  * // ]
  */
-export function wrapTextByWords(
-  text: string,
-  maxWidth: number,
-): WrappedLine[] {
+export function wrapTextByWords(text: string, maxWidth: number): WrappedLine[] {
   const lines: WrappedLine[] = [];
 
   if (maxWidth <= 0) return [{ text: text, start: 0 }];
@@ -125,9 +122,7 @@ function tokenizeText(text: string): Token[] {
 
   for (const char of text) {
     const isWhitespace = /\s/.test(char);
-    const charType: "word" | "whitespace" = isWhitespace
-      ? "whitespace"
-      : "word";
+    const charType: "word" | "whitespace" = isWhitespace ? "whitespace" : "word";
 
     if (currentType === null) {
       currentType = charType;

--- a/src/hooks/use_mouse_pointer.test.tsx
+++ b/src/hooks/use_mouse_pointer.test.tsx
@@ -1,10 +1,7 @@
-import { testRender } from "@opentui/react/test-utils";
 import { expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
 import { act, useEffect } from "react";
-import {
-  setMousePointerWriterForTest,
-  useMousePointer,
-} from "./use_mouse_pointer.ts";
+import { setMousePointerWriterForTest, useMousePointer } from "./use_mouse_pointer.ts";
 
 const pointerWrites: string[] = [];
 
@@ -48,10 +45,7 @@ test("useMousePointer writes OSC 22 sequences only when the style changes", asyn
   await tui.renderOnce();
 
   expect(tui.captureCharFrame()).toContain("pointer:ew-resize,ew-resize,default");
-  expect(pointerWrites).toEqual([
-    "\x1b]22;ew-resize\x1b\\",
-    "\x1b]22;default\x1b\\",
-  ]);
+  expect(pointerWrites).toEqual(["\x1b]22;ew-resize\x1b\\", "\x1b]22;default\x1b\\"]);
 
   act(() => {
     tui.renderer.destroy();

--- a/src/hooks/use_mouse_pointer.ts
+++ b/src/hooks/use_mouse_pointer.ts
@@ -1,41 +1,39 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 import { useCallback, useRef } from "react";
 
-
 export type MousePointerStyle =
-  | "default"       // The platform-dependent default cursor
-  | "pointer"       // A pointing hand, typically used for links
-  | "text"          // An I-beam cursor for text selection
-  | "crosshair"     // A thin crosshair cursor
-  | "move"          // An arrow cursor indicating something can be moved
-  | "not-allowed"   // Indicates that an action is prohibited
-  | "wait"          // An hourglass or spinning wheel indicating the UI is busy
-  | "progress"      // An arrow with a small wait indicator showing background activity
-  | "help"          // An arrow with a question mark indicating help is available
-  | "grab"          // An open hand, indicating something can be gripped
-  | "grabbing"      // A closed hand, indicating something is being dragged
-  | "zoom-in"       // A magnifying glass with a plus sign
-  | "zoom-out"      // A magnifying glass with a minus sign
-  | "e-resize"      // Indicates an edge is to be moved east (right)
-  | "w-resize"      // Indicates an edge is to be moved west (left)
-  | "s-resize"      // Indicates an edge is to be moved south (down)
-  | "n-resize"      // Indicates an edge is to be moved north (up)
-  | "ne-resize"     // Indicates an edge is to be moved north-east (up-right)
-  | "nw-resize"     // Indicates an edge is to be moved north-west (up-left)
-  | "se-resize"     // Indicates an edge is to be moved south-east (down-right)
-  | "sw-resize"     // Indicates an edge is to be moved south-west (down-left)
-  | "ew-resize"     // A bidirectional cursor for horizontal resizing
-  | "ns-resize"     // A bidirectional cursor for vertical resizing
-  | "nesw-resize"   // A bidirectional cursor for diagonal resizing (top-right to bottom-left)
-  | "nwse-resize"   // A bidirectional cursor for diagonal resizing (top-left to bottom-right)
-  | "col-resize"    // Indicates a column can be resized horizontally
-  | "row-resize"    // Indicates a row can be resized vertically
-  | "all-scroll"    // Indicates that the view can be scrolled in any direction
+  | "default" // The platform-dependent default cursor
+  | "pointer" // A pointing hand, typically used for links
+  | "text" // An I-beam cursor for text selection
+  | "crosshair" // A thin crosshair cursor
+  | "move" // An arrow cursor indicating something can be moved
+  | "not-allowed" // Indicates that an action is prohibited
+  | "wait" // An hourglass or spinning wheel indicating the UI is busy
+  | "progress" // An arrow with a small wait indicator showing background activity
+  | "help" // An arrow with a question mark indicating help is available
+  | "grab" // An open hand, indicating something can be gripped
+  | "grabbing" // A closed hand, indicating something is being dragged
+  | "zoom-in" // A magnifying glass with a plus sign
+  | "zoom-out" // A magnifying glass with a minus sign
+  | "e-resize" // Indicates an edge is to be moved east (right)
+  | "w-resize" // Indicates an edge is to be moved west (left)
+  | "s-resize" // Indicates an edge is to be moved south (down)
+  | "n-resize" // Indicates an edge is to be moved north (up)
+  | "ne-resize" // Indicates an edge is to be moved north-east (up-right)
+  | "nw-resize" // Indicates an edge is to be moved north-west (up-left)
+  | "se-resize" // Indicates an edge is to be moved south-east (down-right)
+  | "sw-resize" // Indicates an edge is to be moved south-west (down-left)
+  | "ew-resize" // A bidirectional cursor for horizontal resizing
+  | "ns-resize" // A bidirectional cursor for vertical resizing
+  | "nesw-resize" // A bidirectional cursor for diagonal resizing (top-right to bottom-left)
+  | "nwse-resize" // A bidirectional cursor for diagonal resizing (top-left to bottom-right)
+  | "col-resize" // Indicates a column can be resized horizontally
+  | "row-resize" // Indicates a row can be resized vertically
+  | "all-scroll" // Indicates that the view can be scrolled in any direction
   | "vertical-text" // An I-beam cursor for vertical text selection
-  | "copy"          // An arrow with a plus sign indicating a copy will be made
-  | "alias"         // An arrow indicating a shortcut or alias will be created
-  | "no-drop";      // Indicates that an item cannot be dropped at the current location
-
+  | "copy" // An arrow with a plus sign indicating a copy will be made
+  | "alias" // An arrow indicating a shortcut or alias will be created
+  | "no-drop"; // Indicates that an item cannot be dropped at the current location
 
 type MousePointerWriter = (output: string) => void;
 
@@ -52,7 +50,7 @@ function createMousePointerWriter(): MousePointerWriter {
   } catch {
     // In CI/sandbox environments, /dev/tty may be unavailable.
     // Fall back to a no-op writer so pointer updates do not crash rendering/tests.
-    mousePointerWriter = () => { };
+    mousePointerWriter = () => {};
     return mousePointerWriter;
   }
 

--- a/src/lib/editor_engine/commit/commit_engine.ts
+++ b/src/lib/editor_engine/commit/commit_engine.ts
@@ -6,12 +6,7 @@ import { SubjectNode } from "./subject.ts";
 import { TypeNode } from "./type.ts";
 
 export function createCommitEngine(): PromptEngine<CommitContext> {
-  const nodes = [
-    new TypeNode(),
-    new ScopeNode(),
-    new SeparatorNode(),
-    new SubjectNode(),
-  ];
+  const nodes = [new TypeNode(), new ScopeNode(), new SeparatorNode(), new SubjectNode()];
 
   return new PromptEngine(nodes, "type");
 }
@@ -22,9 +17,7 @@ console.log("=== Test 1: Incomplete type 'fea' (cursor=3, selectIndex=0) ===");
 console.log(await engine.analyze("fea", 3, 0));
 console.log("\n");
 
-console.log(
-  "=== Test 2: Complete type 'feat' (cursor=4, selectIndex=1 for ': ') ===",
-);
+console.log("=== Test 2: Complete type 'feat' (cursor=4, selectIndex=1 for ': ') ===");
 console.log(await engine.analyze("feat", 4, 1));
 console.log("\n");
 

--- a/src/lib/editor_engine/commit/commitlint_provider.ts
+++ b/src/lib/editor_engine/commit/commitlint_provider.ts
@@ -42,9 +42,7 @@ export class CommitlintProvider {
   private config: QualifiedConfig | null = null;
 
   async init(userConfig?: Parameters<typeof load>[0]): Promise<void> {
-    this.config = await load(
-      userConfig ?? { extends: ["@commitlint/config-conventional"] },
-    );
+    this.config = await load(userConfig ?? { extends: ["@commitlint/config-conventional"] });
   }
 
   /** type-enum ルールから prefix に前方一致する補完候補を返す */

--- a/src/lib/editor_engine/commit/commitlint_standalone.ts
+++ b/src/lib/editor_engine/commit/commitlint_standalone.ts
@@ -13,11 +13,7 @@ import { lint, load } from "@commitlint/core";
 import type { QualifiedConfig } from "@commitlint/types";
 import { ConsoleNode } from "../console_node.ts";
 import { PromptEngine } from "../prompt_engine.ts";
-import type {
-  CompletionItem,
-  FragmentContext,
-  TextFragment,
-} from "../types.ts";
+import type { CompletionItem, FragmentContext, TextFragment } from "../types.ts";
 
 // ---------------------------------------------------------------------------
 // CommitContext
@@ -35,26 +31,24 @@ interface CommitContext extends Record<string, string> {
 // ---------------------------------------------------------------------------
 
 const TYPE_DESCRIPTIONS: Record<string, string> = {
-  feat:     "✨ New feature",
-  fix:      "🐛 Bug fix",
-  docs:     "📝 Documentation",
-  style:    "💄 Formatting / styling",
+  feat: "✨ New feature",
+  fix: "🐛 Bug fix",
+  docs: "📝 Documentation",
+  style: "💄 Formatting / styling",
   refactor: "♻️  Code refactoring",
-  test:     "✅ Add / fix tests",
-  chore:    "🔧 Maintenance",
-  perf:     "⚡ Performance improvement",
-  ci:       "👷 CI/CD changes",
-  build:    "📦 Build system",
-  revert:   "⏪ Revert changes",
+  test: "✅ Add / fix tests",
+  chore: "🔧 Maintenance",
+  perf: "⚡ Performance improvement",
+  ci: "👷 CI/CD changes",
+  build: "📦 Build system",
+  revert: "⏪ Revert changes",
 };
 
 class CommitlintProvider {
   private config: QualifiedConfig | null = null;
 
   async init(userConfig?: Parameters<typeof load>[0]): Promise<void> {
-    this.config = await load(
-      userConfig ?? { extends: ["@commitlint/config-conventional"] },
-    );
+    this.config = await load(userConfig ?? { extends: ["@commitlint/config-conventional"] });
   }
 
   getTypes(prefix: string): CompletionItem[] {
@@ -134,9 +128,9 @@ class TypeNode extends ConsoleNode<CommitContext> {
 
   constructor(private provider: CommitlintProvider) {
     super([
-      { to: "scope",     trigger: /^\w+(?=\()/ },
+      { to: "scope", trigger: /^\w+(?=\()/ },
       { to: "separator", trigger: /^\w+(?=!?:)/ },
-      { to: "type",      trigger: /^\w+/ },
+      { to: "type", trigger: /^\w+/ },
     ]);
   }
 
@@ -155,7 +149,7 @@ class ScopeNode extends ConsoleNode<CommitContext> {
   constructor(private provider: CommitlintProvider) {
     super([
       { to: "separator", trigger: /^\([^)]+\)(?=!?:)/ },
-      { to: "scope",     trigger: /^\([^)]*/ },
+      { to: "scope", trigger: /^\([^)]*/ },
     ]);
   }
 
@@ -225,12 +219,7 @@ export async function createStandaloneCommitEngine(
   await provider.init(userConfig);
 
   const engine = new PromptEngine<CommitContext>(
-    [
-      new TypeNode(provider),
-      new ScopeNode(provider),
-      new SeparatorNode(),
-      new SubjectNode(),
-    ],
+    [new TypeNode(provider), new ScopeNode(provider), new SeparatorNode(), new SubjectNode()],
     "type",
   );
 
@@ -250,13 +239,13 @@ const { engine, provider } = await createStandaloneCommitEngine({
 });
 
 const cases = [
-  { label: "type 途中 'fe'",              input: "fe",                    cursor: 2  },
-  { label: "type 確定 'feat'",            input: "feat",                  cursor: 4  },
-  { label: "scope 途中 'feat(ap'",        input: "feat(ap",               cursor: 7  },
-  { label: "scope 確定 'feat(api): '",    input: "feat(api): ",           cursor: 11 },
-  { label: "subject 入力 'feat: add x'",  input: "feat: add x",           cursor: 11 },
-  { label: "breaking 'feat!: '",          input: "feat!: ",               cursor: 7  },
-  { label: "長い subject (75文字超え)",    input: "feat: " + "a".repeat(75), cursor: 81 },
+  { label: "type 途中 'fe'", input: "fe", cursor: 2 },
+  { label: "type 確定 'feat'", input: "feat", cursor: 4 },
+  { label: "scope 途中 'feat(ap'", input: "feat(ap", cursor: 7 },
+  { label: "scope 確定 'feat(api): '", input: "feat(api): ", cursor: 11 },
+  { label: "subject 入力 'feat: add x'", input: "feat: add x", cursor: 11 },
+  { label: "breaking 'feat!: '", input: "feat!: ", cursor: 7 },
+  { label: "長い subject (75文字超え)", input: "feat: " + "a".repeat(75), cursor: 81 },
 ];
 
 console.log("=== スタンドアロン commitlint エンジン デモ ===\n");
@@ -269,9 +258,9 @@ for (const { label, input, cursor } of cases) {
   // フラグメント表示
   const rendered = fragment
     .map((f) => {
-      if (f.role === "ghost")  return `\x1b[2m${f.text}\x1b[0m`; // dim
-      if (f.role === "error")  return `\x1b[31m${f.text}\x1b[0m`; // red
-      if (f.role === "meta")   return `\x1b[90m${f.text}\x1b[0m`; // gray
+      if (f.role === "ghost") return `\x1b[2m${f.text}\x1b[0m`; // dim
+      if (f.role === "error") return `\x1b[31m${f.text}\x1b[0m`; // red
+      if (f.role === "meta") return `\x1b[90m${f.text}\x1b[0m`; // gray
       return f.text;
     })
     .join("");
@@ -289,7 +278,7 @@ for (const { label, input, cursor } of cases) {
 
   // バリデーション
   const v = await provider.validate(input.trim());
-  if (!v.valid)             console.log(`   ❌ ${v.errors.join(" / ")}`);
+  if (!v.valid) console.log(`   ❌ ${v.errors.join(" / ")}`);
   else if (v.warnings.length) console.log(`   ⚠️  ${v.warnings.join(" / ")}`);
 
   console.log();

--- a/src/lib/editor_engine/commit/scope.ts
+++ b/src/lib/editor_engine/commit/scope.ts
@@ -1,9 +1,5 @@
 import { ConsoleNode } from "../console_node.ts";
-import type {
-  CompletionItem,
-  FragmentContext,
-  TextFragment,
-} from "../types.ts";
+import type { CompletionItem, FragmentContext, TextFragment } from "../types.ts";
 import type { CommitContext } from "./context.ts";
 
 export class ScopeNode extends ConsoleNode<CommitContext> {

--- a/src/lib/editor_engine/commit/separator.test.ts
+++ b/src/lib/editor_engine/commit/separator.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
+
 import { SeparatorNode } from "./separator.ts";
 
 test("SeparatorNode - trigger: /^!?:\\s*/ matches colon separator", () => {

--- a/src/lib/editor_engine/commit/separator.ts
+++ b/src/lib/editor_engine/commit/separator.ts
@@ -6,9 +6,7 @@ export class SeparatorNode extends ConsoleNode<CommitContext> {
   id = "separator" as const;
 
   constructor() {
-    super(
-      [{ to: "subject", trigger: /^!?:\s*/ }],
-    );
+    super([{ to: "subject", trigger: /^!?:\s*/ }]);
   }
 
   getSuggestions(_input: string): Promise<CompletionItem[]> {

--- a/src/lib/editor_engine/commit/subject.test.ts
+++ b/src/lib/editor_engine/commit/subject.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 const assertEquals = (actual: unknown, expected: unknown) => {
   expect(actual).toEqual(expected);
 };
+
 import { SubjectNode } from "./subject.ts";
 
 test("SubjectNode - trigger: /^[\\s\\S]+/ matches any non-empty content", () => {
@@ -86,9 +87,7 @@ test("SubjectNode - trigger: real-world examples", () => {
 
   // Long subject
   assertEquals(
-    trigger.test(
-      "add comprehensive error handling for API requests with retry logic",
-    ),
+    trigger.test("add comprehensive error handling for API requests with retry logic"),
     true,
   );
 

--- a/src/lib/editor_engine/commit/subject.ts
+++ b/src/lib/editor_engine/commit/subject.ts
@@ -6,9 +6,7 @@ export class SubjectNode extends ConsoleNode<CommitContext> {
   override id = "subject" as const;
 
   constructor() {
-    super([
-      { to: "subject", trigger: /^[\s\S]+/ },
-    ]);
+    super([{ to: "subject", trigger: /^[\s\S]+/ }]);
   }
 
   getSuggestions(): Promise<CompletionItem[]> {

--- a/src/lib/editor_engine/commit/type.ts
+++ b/src/lib/editor_engine/commit/type.ts
@@ -1,9 +1,5 @@
 import { ConsoleNode } from "../console_node.ts";
-import type {
-  CompletionItem,
-  FragmentContext,
-  TextFragment,
-} from "../types.ts";
+import type { CompletionItem, FragmentContext, TextFragment } from "../types.ts";
 import type { CommitContext } from "./context.ts";
 
 export class TypeNode extends ConsoleNode<CommitContext> {

--- a/src/lib/editor_engine/console_node.ts
+++ b/src/lib/editor_engine/console_node.ts
@@ -1,20 +1,11 @@
-import type {
-  CompletionItem,
-  FragmentContext,
-  TextFragment,
-  Transition,
-} from "./types.ts";
+import type { CompletionItem, FragmentContext, TextFragment, Transition } from "./types.ts";
 
 export abstract class ConsoleNode<T> {
   abstract id: keyof T;
 
-  constructor(
-    public next: Transition<T>[],
-  ) {}
+  constructor(public next: Transition<T>[]) {}
 
-  abstract getSuggestions(
-    input: string,
-  ): Promise<CompletionItem[]>;
+  abstract getSuggestions(input: string): Promise<CompletionItem[]>;
 
   render(ctx: FragmentContext): TextFragment[] {
     const { value } = ctx;

--- a/src/lib/editor_engine/prompt_engine.ts
+++ b/src/lib/editor_engine/prompt_engine.ts
@@ -26,9 +26,7 @@ export class PromptEngine<T extends Record<string, string>> {
       const currentNode = this.nodeMap.get(currentNodeId);
       if (!currentNode) break;
 
-      const transition = currentNode.next.find((t) =>
-        t.trigger.test(remaining)
-      );
+      const transition = currentNode.next.find((t) => t.trigger.test(remaining));
       if (!transition) break;
 
       const match = remaining.match(transition.trigger);
@@ -36,8 +34,7 @@ export class PromptEngine<T extends Record<string, string>> {
 
       const [value] = match;
 
-      const isPrimary = consumed <= cursor &&
-        cursor <= (consumed + value.length);
+      const isPrimary = consumed <= cursor && cursor <= consumed + value.length;
 
       const completions = await currentNode.getSuggestions(value);
       if (isPrimary) {

--- a/src/lib/opentui_testing.test.tsx
+++ b/src/lib/opentui_testing.test.tsx
@@ -44,13 +44,10 @@ function KeyboardAwareOpenTuiMarkup() {
 }
 
 test("@opentui/react/test-utils renders static OpenTUI markup", async () => {
-  const tui = await testRender(
-    <StaticOpenTuiMarkup />,
-    {
-      width: 40,
-      height: 8,
-    },
-  );
+  const tui = await testRender(<StaticOpenTuiMarkup />, {
+    width: 40,
+    height: 8,
+  });
 
   await tui.renderOnce();
 
@@ -62,13 +59,10 @@ test("@opentui/react/test-utils renders static OpenTUI markup", async () => {
 });
 
 test("@opentui/react/test-utils renders hook-based OpenTUI components", async () => {
-  const tui = await testRender(
-    <RendererAwareOpenTuiMarkup />,
-    {
-      width: 40,
-      height: 8,
-    },
-  );
+  const tui = await testRender(<RendererAwareOpenTuiMarkup />, {
+    width: 40,
+    height: 8,
+  });
 
   await tui.renderOnce();
 
@@ -80,13 +74,10 @@ test("@opentui/react/test-utils renders hook-based OpenTUI components", async ()
 });
 
 test("@opentui/react/test-utils can drive keyboard interaction", async () => {
-  const tui = await testRender(
-    <KeyboardAwareOpenTuiMarkup />,
-    {
-      width: 40,
-      height: 8,
-    },
-  );
+  const tui = await testRender(<KeyboardAwareOpenTuiMarkup />, {
+    width: 40,
+    height: 8,
+  });
 
   await tui.renderOnce();
   expect(tui.captureCharFrame()).toContain("status:idle");

--- a/src/lib/runner.tsx
+++ b/src/lib/runner.tsx
@@ -1,23 +1,54 @@
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import { Provider } from "react-redux";
-import { createAppStore, type AppDependencies } from "../app/store.ts";
+import { type AppDependencies, type AppStore, createAppStore } from "../app/store.ts";
 import { AppDependenciesProvider } from "../contexts/app_dependencies_context.tsx";
 import { ThemeModeProvider } from "../contexts/theme_mode_context.tsx";
 
-export async function runTui(
-  component: React.ReactNode,
-) {
-  const renderer = await createCliRenderer({
-    backgroundColor: "#FF00FF",
-  })
-  createRoot(renderer).render(
-    <ThemeModeProvider>
-      {component}
-    </ThemeModeProvider>
-  )
+/** OpenTUI の `createRoot` 直下。`useRenderer()` が必要なので最外側。 */
+function TuiThemeShell({ children }: { children: React.ReactNode }) {
+  return <ThemeModeProvider>{children}</ThemeModeProvider>;
 }
 
+/**
+ * Redux と DI 用コンテキストをまとめる（順序固定: store → dependencies）。
+ * Thunk の extraArgument と揃えて、コンポーネントからも `useAppDependencies` で参照できるようにする。
+ */
+function TuiReduxAppProviders({
+  store,
+  dependencies,
+  children,
+}: {
+  store: AppStore;
+  dependencies: AppDependencies;
+  children: React.ReactNode;
+}) {
+  return (
+    <Provider store={store}>
+      <AppDependenciesProvider value={dependencies}>{children}</AppDependenciesProvider>
+    </Provider>
+  );
+}
+
+export async function runFullScreenTui(component: React.ReactNode) {
+  const renderer = await createCliRenderer({
+    backgroundColor: "#FF00FF",
+  });
+  createRoot(renderer).render(<TuiThemeShell>{component}</TuiThemeShell>);
+}
+
+export async function runInlineTui(component: React.ReactNode) {
+  const renderer = await createCliRenderer({
+    backgroundColor: "#FF00FF",
+    screenMode: "split-footer",
+    footerHeight: 1,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    useMouse: false,
+    clearOnShutdown: false,
+  });
+  createRoot(renderer).render(<TuiThemeShell>{component}</TuiThemeShell>);
+}
 
 export type RunTuiWithReduxOptions = {
   dependencies: AppDependencies;
@@ -35,9 +66,9 @@ export async function runTuiWithRedux(
     dependencies,
   });
 
-  await runTui(
-    <Provider store={store}>
-      <AppDependenciesProvider value={dependencies}>{component}</AppDependenciesProvider>
-    </Provider>,
+  await runFullScreenTui(
+    <TuiReduxAppProviders store={store} dependencies={dependencies}>
+      {component}
+    </TuiReduxAppProviders>,
   );
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -32,4 +32,3 @@ test("createMainCommand passes noColor to help settings", () => {
   const defaultCmd = createMainCommand(dependencies);
   expect(noColorCmd.getName()).toBe(defaultCmd.getName());
 });
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,9 +11,7 @@ import { createInitCommand } from "./commands/init.tsx";
 import { createIssueCommand } from "./commands/issue.tsx";
 import { ENV_KEYS } from "./repositories/env/env_repository.ts";
 
-export function createMainCommand(
-  dependencies: AppDependencies = createAppDependencies(),
-) {
+export function createMainCommand(dependencies: AppDependencies = createAppDependencies()) {
   return new Command()
     .name(packageJson.name)
     .version(packageJson.version)
@@ -33,7 +31,7 @@ export function createMainCommand(
     .command("issue", createIssueCommand(dependencies))
     .command("commit", createCommitCommand(dependencies))
     .command("completions", new CompletionsCommand())
-    .command("upgrade", new UpgradeCommand({ provider: [new NpmProvider()] }),);
+    .command("upgrade", new UpgradeCommand({ provider: [new NpmProvider()] }));
 }
 
 if (import.meta.main) {

--- a/src/repositories/env/env_repository.ts
+++ b/src/repositories/env/env_repository.ts
@@ -3,7 +3,10 @@ import { EnvError } from "../../lib/errors.ts";
 import type { Credentials } from "../../services/credential/credentials_schema.ts";
 
 export const ENV_KEYS = {
-  OPEN_ROUTER_API_KEY: { key: "GITOGITO_OPEN_ROUTER_API_KEY", description: "API key for OpenRouter." },
+  OPEN_ROUTER_API_KEY: {
+    key: "GITOGITO_OPEN_ROUTER_API_KEY",
+    description: "API key for OpenRouter.",
+  },
   GEMINI_API_KEY: { key: "GITOGITO_GEMINI_API_KEY", description: "API key for Google Gemini." },
   GITHUB_TOKEN: { key: "GITOGITO_GITHUB_TOKEN", description: "GitHub personal access token." },
   NO_COLOR: { key: "NO_COLOR", description: "Disable color output when set (any value)." },
@@ -17,11 +20,14 @@ export interface EnvRepository {
 
 export class EnvRepositoryProcessImpl implements EnvRepository {
   getCredentials(): Partial<Credentials> {
-    return _.omitBy({
-      openRouterApiKey: process.env[ENV_KEYS.OPEN_ROUTER_API_KEY.key],
-      geminiApiKey: process.env[ENV_KEYS.GEMINI_API_KEY.key],
-      githubToken: process.env[ENV_KEYS.GITHUB_TOKEN.key],
-    }, _.isUndefined) as Partial<Credentials>;
+    return _.omitBy(
+      {
+        openRouterApiKey: process.env[ENV_KEYS.OPEN_ROUTER_API_KEY.key],
+        geminiApiKey: process.env[ENV_KEYS.GEMINI_API_KEY.key],
+        githubToken: process.env[ENV_KEYS.GITHUB_TOKEN.key],
+      },
+      _.isUndefined,
+    ) as Partial<Credentials>;
   }
   getNoColor(): boolean {
     return process.env[ENV_KEYS.NO_COLOR.key] !== undefined;

--- a/src/repositories/git/diff_repository.ts
+++ b/src/repositories/git/diff_repository.ts
@@ -1,5 +1,5 @@
-import git from "isomorphic-git";
 import fs from "node:fs";
+import git from "isomorphic-git";
 import { simpleGit } from "simple-git";
 
 /**
@@ -13,9 +13,7 @@ export interface GitDiffRepository {
   getGitDiffUnstagedName(): Promise<string>;
   getUnStagedFileNames(): Promise<string[]>;
   /** Read file content from HEAD and STAGE for TUI diff display */
-  getBlobsForDiff(
-    filepath: string,
-  ): Promise<{ headText: string; stageText: string }>;
+  getBlobsForDiff(filepath: string): Promise<{ headText: string; stageText: string }>;
 }
 
 /**
@@ -50,9 +48,7 @@ export class GitDiffRepositoryCliImpl implements GitDiffRepository {
     return raw.split(/\r?\n/).filter(Boolean);
   }
 
-  async getBlobsForDiff(
-    filepath: string,
-  ): Promise<{ headText: string; stageText: string }> {
+  async getBlobsForDiff(filepath: string): Promise<{ headText: string; stageText: string }> {
     const dir = await git.findRoot({ fs, filepath: process.cwd() });
 
     let headText = "";
@@ -76,10 +72,8 @@ export class GitDiffRepositoryCliImpl implements GitDiffRepository {
           trees: [git.STAGE()],
           map: async (walkPath, [entry]) => {
             if (walkPath !== filepath || !entry) return;
-            if (await entry.type() === "tree") return;
-            stageText = new TextDecoder().decode(
-              await entry.content() as Uint8Array,
-            );
+            if ((await entry.type()) === "tree") return;
+            stageText = new TextDecoder().decode((await entry.content()) as Uint8Array);
           },
         });
       }

--- a/src/repositories/git/status_repository.ts
+++ b/src/repositories/git/status_repository.ts
@@ -12,8 +12,8 @@ export interface GitStatusRepository {
  */
 export class GitStatusRepositoryCliImpl implements GitStatusRepository {
   async getStatus(): Promise<string> {
-    return simpleGit().status().then((s) =>
-      s.files.map((f) => `${f.index}${f.working_dir} ${f.path}`).join("\n")
-    );
+    return simpleGit()
+      .status()
+      .then((s) => s.files.map((f) => `${f.index}${f.working_dir} ${f.path}`).join("\n"));
   }
 }

--- a/src/services/ai/ai_service.ts
+++ b/src/services/ai/ai_service.ts
@@ -1,22 +1,13 @@
-import {
-  generateObject,
-  type LanguageModel,
-  type ModelMessage,
-  streamObject,
-} from "ai";
-import { z } from "zod";
-import {
-  createConfigService,
-  type ConfigService,
-} from "../config/config_service.ts";
+import { generateObject, type LanguageModel, type ModelMessage, streamObject } from "ai";
+import type { z } from "zod";
+import { type ConfigService, createConfigService } from "../config/config_service.ts";
 import { AiConfigSchema } from "../config/schema/fields/ai_schema.ts";
-import type { Credentials } from "../credential/credentials_schema.ts";
 import {
-  createCredentialService,
   type CredentialService,
+  createCredentialService,
 } from "../credential/credential_service.ts";
-import { createLanguageModel } from "./provider.ts";
-import { normalizeAiProvider } from "./provider.ts";
+import type { Credentials } from "../credential/credentials_schema.ts";
+import { createLanguageModel, normalizeAiProvider } from "./provider.ts";
 import type { AiProvider, AiTask, UsageCallback } from "./types.ts";
 
 export class AIService {
@@ -25,11 +16,7 @@ export class AIService {
   protected model: string;
   protected credentials: Partial<Credentials>;
 
-  constructor(
-    provider: AiProvider,
-    model: string,
-    credentials: Partial<Credentials>,
-  ) {
+  constructor(provider: AiProvider, model: string, credentials: Partial<Credentials>) {
     this.provider = provider;
     this.model = model;
     this.credentials = credentials;
@@ -37,10 +24,7 @@ export class AIService {
 
   static async create(
     configSource: Pick<ConfigService, "getMergedConfig"> = createConfigService(),
-    credentialSource: Pick<
-      CredentialService,
-      "getMergedCredentials"
-    > = createCredentialService(),
+    credentialSource: Pick<CredentialService, "getMergedCredentials"> = createCredentialService(),
     task?: AiTask,
   ): Promise<AIService> {
     const mergedConfig = await configSource.getMergedConfig();

--- a/src/services/config/config_file.ts
+++ b/src/services/config/config_file.ts
@@ -12,31 +12,18 @@ export interface ConfigFile {
 }
 
 export class ConfigFileImpl implements ConfigFile {
-  constructor(
-    private envRepository: EnvRepository,
-  ) { }
+  constructor(private envRepository: EnvRepository) {}
 
   private getGlobalPath() {
-    return join(
-      this.envRepository.getHome(),
-      ".config",
-      packageJson.name,
-      "config.yml",
-    );
+    return join(this.envRepository.getHome(), ".config", packageJson.name, "config.yml");
   }
 
   private getProjectPath() {
-    return join(
-      process.cwd(),
-      `.${packageJson.name}.yml`,
-    );
+    return join(process.cwd(), `.${packageJson.name}.yml`);
   }
 
   private getLocalPath() {
-    return join(
-      process.cwd(),
-      `.${packageJson.name}.local.yml`,
-    );
+    return join(process.cwd(), `.${packageJson.name}.local.yml`);
   }
 
   private getFilePath(configScope: ConfigScope): string {
@@ -83,14 +70,15 @@ export class ConfigFileImpl implements ConfigFile {
   }
 }
 
-export function createConfigFile(
-  envRepository: EnvRepository = createEnvRepository(),
-): ConfigFile {
+export function createConfigFile(envRepository: EnvRepository = createEnvRepository()): ConfigFile {
   return new ConfigFileImpl(envRepository);
 }
 
 function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
-  return typeof error === "object" && error !== null &&
+  return (
+    typeof error === "object" &&
+    error !== null &&
     "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT";
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
 }

--- a/src/services/config/config_service.test.ts
+++ b/src/services/config/config_service.test.ts
@@ -44,7 +44,8 @@ test("getMergedConfig - deeply merges nested config with defaults", async () => 
 
 test("getMergedConfig - credentials field in file is ignored", async () => {
   const file = new ConfigFileMock({
-    global: "ai:\n  default:\n    provider: OpenRouter\ncredentials:\n  openRouterApiKey: sk-secret\n",
+    global:
+      "ai:\n  default:\n    provider: OpenRouter\ncredentials:\n  openRouterApiKey: sk-secret\n",
   });
   const service = new ConfigServiceImpl(file);
 
@@ -58,7 +59,8 @@ test("getMergedConfig - credentials field in file is ignored", async () => {
 
 test("getGlobalConfig - returns ai/language/theme fields (no commit, no credentials)", async () => {
   const file = new ConfigFileMock({
-    global: "ai:\n  default:\n    provider: OpenRouter\n    model: gpt-4o\nlanguage:\n  dialogue: Japanese\n",
+    global:
+      "ai:\n  default:\n    provider: OpenRouter\n    model: gpt-4o\nlanguage:\n  dialogue: Japanese\n",
   });
   const service = new ConfigServiceImpl(file);
 
@@ -108,13 +110,14 @@ test("getLocalConfig - returns overrides without credentials", async () => {
 
 test("saveConfig - preserves existing comments", async () => {
   const file = new ConfigFileMock({
-    project: [
-      "# AI settings",
-      "ai:",
-      "  default:",
-      "    provider: Ollama # current provider",
-      "    model: qwen3.5:9b",
-    ].join("\n") + "\n",
+    project:
+      [
+        "# AI settings",
+        "ai:",
+        "  default:",
+        "    provider: Ollama # current provider",
+        "    model: qwen3.5:9b",
+      ].join("\n") + "\n",
   });
   const service = new ConfigServiceImpl(file);
 

--- a/src/services/config/config_service.ts
+++ b/src/services/config/config_service.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
 import { parse, parseDocument } from "yaml";
 import type { NestedKeys, PathValue } from "../../type.ts";
-import { createConfigFile, type ConfigFile, type ConfigScope } from "./config_file.ts";
+import { type ConfigFile, type ConfigScope, createConfigFile } from "./config_file.ts";
 import { type Config, DEFAULT_CONFIG } from "./schema/config_schema.ts";
-import { GlobalConfigSchema, type GlobalConfig } from "./schema/global_config_schema.ts";
-import { LocalConfigSchema, type LocalConfig } from "./schema/local_config_schema.ts";
-import { ProjectConfigSchema, type ProjectConfig } from "./schema/project_config_schema.ts";
+import { type GlobalConfig, GlobalConfigSchema } from "./schema/global_config_schema.ts";
+import { type LocalConfig, LocalConfigSchema } from "./schema/local_config_schema.ts";
+import { type ProjectConfig, ProjectConfigSchema } from "./schema/project_config_schema.ts";
 
 export interface ConfigService {
   getGlobalConfig(): Promise<Partial<GlobalConfig>>;

--- a/src/services/config/schema/config_schema.ts
+++ b/src/services/config/schema/config_schema.ts
@@ -4,12 +4,14 @@ import { CommitConfigSchema, DEFAULT_COMMIT_CONFIG } from "./fields/commit_schem
 import { DEFAULT_LANGUAGE, LanguageSchema } from "./fields/language_schema.ts";
 import { DEFAULT_THEME_CONFIG, ThemeConfigSchema } from "./fields/theme_schema.ts";
 
-export const ConfigSchema = z.object({
-  ai: AiConfigSchema.default(DEFAULT_AI_CONFIG).describe("AI settings."),
-  language: LanguageSchema.default(DEFAULT_LANGUAGE).describe("Language settings."),
-  commit: CommitConfigSchema.default(DEFAULT_COMMIT_CONFIG).describe("Commit settings."),
-  theme: ThemeConfigSchema.default(DEFAULT_THEME_CONFIG).describe("Theme settings."),
-}).describe("Root configuration schema. Represents the fully merged config.");
+export const ConfigSchema = z
+  .object({
+    ai: AiConfigSchema.default(DEFAULT_AI_CONFIG).describe("AI settings."),
+    language: LanguageSchema.default(DEFAULT_LANGUAGE).describe("Language settings."),
+    commit: CommitConfigSchema.default(DEFAULT_COMMIT_CONFIG).describe("Commit settings."),
+    theme: ThemeConfigSchema.default(DEFAULT_THEME_CONFIG).describe("Theme settings."),
+  })
+  .describe("Root configuration schema. Represents the fully merged config.");
 
 export type Config = z.infer<typeof ConfigSchema>;
 

--- a/src/services/config/schema/fields/ai_schema.ts
+++ b/src/services/config/schema/fields/ai_schema.ts
@@ -7,19 +7,25 @@ export const AI_PROVIDER = [
   "CodexCLI",
   "ClaudeCode",
   "CodexCLIWithOllama",
-  "ClaudeCodeWithOllama"
+  "ClaudeCodeWithOllama",
 ] as const;
 
-export const AiModelSchema = z.object({
-  provider: z.enum(AI_PROVIDER).describe("AI provider used for generation."),
-  model: z.string().describe("Model name used by the selected AI provider."),
-}).describe("AI model configuration.");
+export const AiModelSchema = z
+  .object({
+    provider: z.enum(AI_PROVIDER).describe("AI provider used for generation."),
+    model: z.string().describe("Model name used by the selected AI provider."),
+  })
+  .describe("AI model configuration.");
 
-export const AiConfigSchema = z.object({
-  default: AiModelSchema.describe("Default model used when no task-specific model is configured."),
-  commit: AiModelSchema.optional().describe("Model used for commit message generation."),
-  issue: AiModelSchema.optional().describe("Model used for issue generation."),
-}).describe("AI configuration.");
+export const AiConfigSchema = z
+  .object({
+    default: AiModelSchema.describe(
+      "Default model used when no task-specific model is configured.",
+    ),
+    commit: AiModelSchema.optional().describe("Model used for commit message generation."),
+    issue: AiModelSchema.optional().describe("Model used for issue generation."),
+  })
+  .describe("AI configuration.");
 
 export type AiModel = z.infer<typeof AiModelSchema>;
 export type AiConfig = z.infer<typeof AiConfigSchema>;

--- a/src/services/config/schema/fields/appearance/ansi_schema.ts
+++ b/src/services/config/schema/fields/appearance/ansi_schema.ts
@@ -17,7 +17,7 @@ const AnsiSchema = z.object({
   bright_magenta: z.string(),
   bright_cyan: z.string(),
   bright_white: z.string(),
-})
+});
 
 export type AnsiSchemaType = z.infer<typeof AnsiSchema>;
 export const AnsiSchemaKeyof = AnsiSchema.keyof().options;

--- a/src/services/config/schema/fields/appearance/color_schema.ts
+++ b/src/services/config/schema/fields/appearance/color_schema.ts
@@ -1,28 +1,32 @@
 import z from "zod";
 import { AnsiSchemaKeyof } from "./ansi_schema";
 
-export const HexColorSchema = z.string().regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/)
-export const ColorSchema = z.union([HexColorSchema, z.enum(AnsiSchemaKeyof)])
+export const HexColorSchema = z.string().regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/);
+export const ColorSchema = z.union([HexColorSchema, z.enum(AnsiSchemaKeyof)]);
 
-export const AppColorSchema = z.object({
-  // --- 1. Base Structure ---
-  surface: ColorSchema.describe("Panel background (e.g., ANSI 8: Bright Black)"),
-  inputBackground: ColorSchema.describe("Input field background (e.g., ANSI 0: Black)"),
-  border: ColorSchema.describe("Default border color (e.g., ANSI 7: White)"),
-  divider: ColorSchema.describe("Separator/Divider color (e.g., ANSI 8: Bright Black)"),
-  text: ColorSchema.describe("Base text color (e.g., ANSI 7: White)"),
+export const AppColorSchema = z
+  .object({
+    // --- 1. Base Structure ---
+    surface: ColorSchema.describe("Panel background (e.g., ANSI 8: Bright Black)"),
+    inputBackground: ColorSchema.describe("Input field background (e.g., ANSI 0: Black)"),
+    border: ColorSchema.describe("Default border color (e.g., ANSI 7: White)"),
+    divider: ColorSchema.describe("Separator/Divider color (e.g., ANSI 8: Bright Black)"),
+    text: ColorSchema.describe("Base text color (e.g., ANSI 7: White)"),
 
-  // --- 2. Semantic & Status ---
-  error: ColorSchema.describe("Error/Fail color (e.g., ANSI 1: Red)"),
-  success: ColorSchema.describe("Success/Pass color (e.g., ANSI 2: Green)"),
-  warning: ColorSchema.describe("Warning/Warn color (e.g., ANSI 3: Yellow)"),
-  info: ColorSchema.describe("Info/Command color (e.g., ANSI 6: Cyan)"),
+    // --- 2. Semantic & Status ---
+    error: ColorSchema.describe("Error/Fail color (e.g., ANSI 1: Red)"),
+    success: ColorSchema.describe("Success/Pass color (e.g., ANSI 2: Green)"),
+    warning: ColorSchema.describe("Warning/Warn color (e.g., ANSI 3: Yellow)"),
+    info: ColorSchema.describe("Info/Command color (e.g., ANSI 6: Cyan)"),
 
-  // --- 3. Interactive & Accent ---
-  primary: ColorSchema.describe("Primary brand color (e.g., ANSI 4: Blue)"),
-  focus: ColorSchema.describe("Focus background (e.g., ANSI 12: Bright Blue)"),
-  selected: ColorSchema.describe("Selection background (e.g., ANSI 14: Bright Cyan)"),
-  borderFocus: ColorSchema.describe("Focused border color (e.g., ANSI 15: Bright White)"),
-}).describe("Color configuration for the CLI theme.");
+    // --- 3. Interactive & Accent ---
+    primary: ColorSchema.describe("Primary brand color (e.g., ANSI 4: Blue)"),
+    focus: ColorSchema.describe("Focus background (e.g., ANSI 12: Bright Blue)"),
+    selected: ColorSchema.describe("Selection background (e.g., ANSI 14: Bright Cyan)"),
+    borderFocus: ColorSchema.describe("Focused border color (e.g., ANSI 15: Bright White)"),
+  })
+  .describe("Color configuration for the CLI theme.");
 
-export const BackgroundColorSchema = ColorSchema.optional().describe("Background color configuration for the CLI theme.");
+export const BackgroundColorSchema = ColorSchema.optional().describe(
+  "Background color configuration for the CLI theme.",
+);

--- a/src/services/config/schema/fields/appearance_schema.ts
+++ b/src/services/config/schema/fields/appearance_schema.ts
@@ -1,10 +1,11 @@
 import z from "zod";
 import { AppColorSchema } from "./appearance/color_schema";
 
-
 export const AppearanceSchema = z.object({
   useNerdFont: z.boolean().default(false),
-  themeMode: z.enum(["light", "dark", "system_or_light", "system_or_dark"]).default("system_or_dark"),
+  themeMode: z
+    .enum(["light", "dark", "system_or_light", "system_or_dark"])
+    .default("system_or_dark"),
   lightModeColor: AppColorSchema,
   darkModeColor: AppColorSchema,
-})
+});

--- a/src/services/config/schema/fields/commit_schema.ts
+++ b/src/services/config/schema/fields/commit_schema.ts
@@ -1,29 +1,31 @@
 import { z } from "zod";
 
-export const CommitConfigSchema = z.object({
-  rules: z.object({
-    maxHeaderLength: z.number().describe(
-      "Maximum number of characters allowed in commit header.",
-    ),
-    requireScope: z.boolean().describe(
-      "Whether commit scope is required when creating commit messages.",
-    ),
-  }).describe("Rules for validating commit message format."),
-  type: z.array(
-    z.object({
-      value: z.string().describe("Commit type value (e.g. feat, fix)."),
-      description: z.string().describe(
-        "Human-readable explanation of the commit type.",
-      ),
-      emoji: z.string().optional().describe(
-        "Optional emoji for the commit type.",
-      ),
-    }),
-  ).describe("Available commit types."),
-  scope: z.array(
-    z.string().describe("Allowed commit scope name."),
-  ).describe("Allowed commit scopes."),
-}).describe("Commit message configuration.");
+export const CommitConfigSchema = z
+  .object({
+    rules: z
+      .object({
+        maxHeaderLength: z
+          .number()
+          .describe("Maximum number of characters allowed in commit header."),
+        requireScope: z
+          .boolean()
+          .describe("Whether commit scope is required when creating commit messages."),
+      })
+      .describe("Rules for validating commit message format."),
+    type: z
+      .array(
+        z.object({
+          value: z.string().describe("Commit type value (e.g. feat, fix)."),
+          description: z.string().describe("Human-readable explanation of the commit type."),
+          emoji: z.string().optional().describe("Optional emoji for the commit type."),
+        }),
+      )
+      .describe("Available commit types."),
+    scope: z
+      .array(z.string().describe("Allowed commit scope name."))
+      .describe("Allowed commit scopes."),
+  })
+  .describe("Commit message configuration.");
 
 export type CommitConfig = z.infer<typeof CommitConfigSchema>;
 

--- a/src/services/config/schema/fields/language_schema.ts
+++ b/src/services/config/schema/fields/language_schema.ts
@@ -1,9 +1,11 @@
 import z from "zod";
 
-export const LanguageSchema = z.object({
-  dialogue: z.string().describe("Language used for interactive dialogue."),
-  output: z.string().describe("Language used for generated output."),
-}).describe("Language configuration.");
+export const LanguageSchema = z
+  .object({
+    dialogue: z.string().describe("Language used for interactive dialogue."),
+    output: z.string().describe("Language used for generated output."),
+  })
+  .describe("Language configuration.");
 
 type Language = z.infer<typeof LanguageSchema>;
 

--- a/src/services/config/schema/fields/theme_schema.ts
+++ b/src/services/config/schema/fields/theme_schema.ts
@@ -1,22 +1,24 @@
 import { z } from "zod";
 
-export const ColorConfigSchema = z.object({
-  backgroundColor: z.string().optional().describe("Background color used by the CLI theme."),
-  surface: z.string().describe("Background color for panels, modals, and floating elements."),
-  inputBackground: z.string().describe("Background color for text input fields."),
-  text: z.string().describe("Base text color. Use DIM modifier for muted/disabled text."),
-  primary: z.string().describe("Primary color used by the CLI theme."),
-  focus: z.string().describe("Background color for focused elements."),
-  selected: z.string().describe("Background color for selected items in lists or menus."),
-  border: z.string().describe("Border color used by the CLI theme."),
-  borderFocus: z.string().describe("Border color for focused elements."),
-  divider: z.string().describe("Color for separators and dividers between panes."),
-  error: z.string().describe("Color for error messages and destructive actions."),
-  warning: z.string().describe("Color for warnings and alerts."),
-  success: z.string().describe("Color for success messages."),
-  info: z.string().describe("Color for informational messages."),
-  cursor: z.string().describe("Cursor color for text inputs."),
-}).describe("Color configuration for the CLI theme.");
+export const ColorConfigSchema = z
+  .object({
+    backgroundColor: z.string().optional().describe("Background color used by the CLI theme."),
+    surface: z.string().describe("Background color for panels, modals, and floating elements."),
+    inputBackground: z.string().describe("Background color for text input fields."),
+    text: z.string().describe("Base text color. Use DIM modifier for muted/disabled text."),
+    primary: z.string().describe("Primary color used by the CLI theme."),
+    focus: z.string().describe("Background color for focused elements."),
+    selected: z.string().describe("Background color for selected items in lists or menus."),
+    border: z.string().describe("Border color used by the CLI theme."),
+    borderFocus: z.string().describe("Border color for focused elements."),
+    divider: z.string().describe("Color for separators and dividers between panes."),
+    error: z.string().describe("Color for error messages and destructive actions."),
+    warning: z.string().describe("Color for warnings and alerts."),
+    success: z.string().describe("Color for success messages."),
+    info: z.string().describe("Color for informational messages."),
+    cursor: z.string().describe("Cursor color for text inputs."),
+  })
+  .describe("Color configuration for the CLI theme.");
 
 export type ColorConfig = z.infer<typeof ColorConfigSchema>;
 
@@ -66,22 +68,24 @@ export const SOLID_LIGHT_THEME_COLORS: ColorConfig = {
 
 export const DEFAULT_COLOR_CONFIG: ColorConfig = SOLID_DARK_THEME_COLORS;
 
-export const ThemeConfigSchema = z.object({
-  mode: z.enum([
-    "AdaptiveDark",
-    "AdaptiveLight",
-    "GenericDark",
-    "GenericLight",
-    "SolidDark",
-    "SolidLight",
-    "Custom"
-  ]).describe(
-    "Theme mode used by the CLI.",
-  ),
-  color: ColorConfigSchema.default(DEFAULT_COLOR_CONFIG).describe(
-    "Color settings for the theme.",
-  ),
-}).describe("Theme configuration.");
+export const ThemeConfigSchema = z
+  .object({
+    mode: z
+      .enum([
+        "AdaptiveDark",
+        "AdaptiveLight",
+        "GenericDark",
+        "GenericLight",
+        "SolidDark",
+        "SolidLight",
+        "Custom",
+      ])
+      .describe("Theme mode used by the CLI."),
+    color: ColorConfigSchema.default(DEFAULT_COLOR_CONFIG).describe(
+      "Color settings for the theme.",
+    ),
+  })
+  .describe("Theme configuration.");
 
 export type ThemeConfig = z.infer<typeof ThemeConfigSchema>;
 

--- a/src/services/config/schema/global_config_schema.ts
+++ b/src/services/config/schema/global_config_schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import type { z } from "zod";
 import { ConfigSchema } from "./config_schema.ts";
 
 export const GlobalConfigSchema = ConfigSchema.omit({ commit: true }).describe(

--- a/src/services/config/schema/local_config_schema.ts
+++ b/src/services/config/schema/local_config_schema.ts
@@ -1,4 +1,4 @@
-import { ConfigSchema, type Config, DEFAULT_CONFIG } from "./config_schema.ts";
+import { type Config, ConfigSchema, DEFAULT_CONFIG } from "./config_schema.ts";
 
 export const LocalConfigSchema = ConfigSchema.describe(
   "Local config schema. Stored in .gitogito.local.yml (personal overrides, not git-managed).",

--- a/src/services/config/schema/project_config_schema.ts
+++ b/src/services/config/schema/project_config_schema.ts
@@ -1,4 +1,4 @@
-import { ConfigSchema, type Config, DEFAULT_CONFIG } from "./config_schema.ts";
+import { type Config, ConfigSchema, DEFAULT_CONFIG } from "./config_schema.ts";
 
 export const ProjectConfigSchema = ConfigSchema.describe(
   "Project config schema. Stored in .gitogito.yml (shared with team).",

--- a/src/services/credential/credential_file.ts
+++ b/src/services/credential/credential_file.ts
@@ -12,15 +12,10 @@ export interface CredentialFile {
 }
 
 export class CredentialFileImpl implements CredentialFile {
-  constructor(private envRepository: EnvRepository) { }
+  constructor(private envRepository: EnvRepository) {}
 
   private getGlobalPath(): string {
-    return join(
-      this.envRepository.getHome(),
-      ".config",
-      packageJson.name,
-      "credentials.yml",
-    );
+    return join(this.envRepository.getHome(), ".config", packageJson.name, "credentials.yml");
   }
 
   private getLocalPath(): string {

--- a/src/services/credential/credential_service.test.ts
+++ b/src/services/credential/credential_service.test.ts
@@ -31,7 +31,10 @@ const envMock: EnvRepository = {
 };
 
 const envMockWithCredentials: EnvRepository = {
-  getCredentials: () => ({ openRouterApiKey: "env-openrouter-key", githubToken: "env-github-token" }),
+  getCredentials: () => ({
+    openRouterApiKey: "env-openrouter-key",
+    githubToken: "env-github-token",
+  }),
   getHome: () => "/tmp",
   getNoColor: () => false,
 };
@@ -122,7 +125,10 @@ test("getMergedCredentials - returns empty object when no files and no env", asy
 test("getMergedCredentials - returns env credentials when no files exist", async () => {
   const service = new CredentialServiceImpl(envMockWithCredentials, new CredentialFileMock());
   const merged = await service.getMergedCredentials();
-  expect(merged).toEqual({ openRouterApiKey: "env-openrouter-key", githubToken: "env-github-token" });
+  expect(merged).toEqual({
+    openRouterApiKey: "env-openrouter-key",
+    githubToken: "env-github-token",
+  });
 });
 
 // --- saveCredentials ---
@@ -157,10 +163,11 @@ test("saveCredentials - works with local scope", async () => {
 
 test("saveCredentials - preserves existing comments", async () => {
   const file = new CredentialFileMock({
-    global: [
-      "# Personal credentials - do not share",
-      "openRouterApiKey: old-key # replace when expired",
-    ].join("\n") + "\n",
+    global:
+      [
+        "# Personal credentials - do not share",
+        "openRouterApiKey: old-key # replace when expired",
+      ].join("\n") + "\n",
   });
   const service = new CredentialServiceImpl(envMock, file);
 

--- a/src/services/credential/credential_service.ts
+++ b/src/services/credential/credential_service.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
 import { parse, parseDocument } from "yaml";
-import type { NestedKeys, PathValue } from "../../type.ts";
 import { createEnvRepository, type EnvRepository } from "../../repositories/env/env_repository.ts";
+import type { NestedKeys, PathValue } from "../../type.ts";
 import {
-  createCredentialFile,
   type CredentialFile,
   type CredentialsScope,
+  createCredentialFile,
 } from "./credential_file.ts";
 import type { Credentials } from "./credentials_schema.ts";
 
@@ -24,7 +24,7 @@ export class CredentialServiceImpl implements CredentialService {
   constructor(
     private envRepository: EnvRepository,
     private credentialFile: CredentialFile,
-  ) { }
+  ) {}
 
   async getGlobalCredentials(): Promise<Partial<Credentials>> {
     const text = await this.credentialFile.load("global");

--- a/src/services/credential/credentials_schema.ts
+++ b/src/services/credential/credentials_schema.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
-export const CredentialsSchema = z.object({
-  openRouterApiKey: z.string().optional().describe("API key for OpenRouter."),
-  geminiApiKey: z.string().optional().describe("API key for Google Gemini."),
-  githubToken: z.string().optional().describe("GitHub personal access token."),
-}).describe("Credentials configuration.");
+export const CredentialsSchema = z
+  .object({
+    openRouterApiKey: z.string().optional().describe("API key for OpenRouter."),
+    geminiApiKey: z.string().optional().describe("API key for Google Gemini."),
+    githubToken: z.string().optional().describe("GitHub personal access token."),
+  })
+  .describe("Credentials configuration.");
 
 export type Credentials = z.infer<typeof CredentialsSchema>;

--- a/src/services/github/issue.ts
+++ b/src/services/github/issue.ts
@@ -3,10 +3,7 @@ import type { IssueCreateResponse } from "../../type.ts";
 import { createCredentialService } from "../credential/credential_service.ts";
 import { GitService } from "../git/git_service.ts";
 
-export async function createIssue(
-  title: string,
-  body: string,
-): Promise<IssueCreateResponse> {
+export async function createIssue(title: string, body: string): Promise<IssueCreateResponse> {
   const gitService = new GitService();
   const credentialService = createCredentialService();
   const { owner, repo } = await gitService.remote.getOwnerAndRepo();

--- a/src/type.ts
+++ b/src/type.ts
@@ -34,13 +34,13 @@ export type CommitConfig = {
 export type IssueCreateResponse = components["schemas"]["issue"];
 
 export type NestedKeys<T> = {
-  [K in keyof T & string]: T[K] extends object
-  ? `${K}` | `${K}.${NestedKeys<T[K]>}`
-  : `${K}`;
+  [K in keyof T & string]: T[K] extends object ? `${K}` | `${K}.${NestedKeys<T[K]>}` : `${K}`;
 }[keyof T & string];
 
-export type PathValue<T, P extends string> = P extends
-  `${infer Key}.${infer Rest}` ? Key extends keyof T ? PathValue<T[Key], Rest>
-  : never
-  : P extends keyof T ? T[P]
-  : never;
+export type PathValue<T, P extends string> = P extends `${infer Key}.${infer Rest}`
+  ? Key extends keyof T
+    ? PathValue<T[Key], Rest>
+    : never
+  : P extends keyof T
+    ? T[P]
+    : never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ESNext"],
+    "lib": [
+      "ESNext"
+    ],
     "jsx": "react-jsx",
     "jsxImportSource": "@opentui/react",
     "strict": true,
@@ -12,7 +14,13 @@
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
-    "types": ["bun-types", "react", "node"],
+    "types": [
+      "bun-types",
+      "react",
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
Closes #189

Summary: Biome + Lefthook + shared VS Code / Zed settings, CI note for `bun check`, `.gitignore` updates, Biome-formatted `src/`, and `useThemeMode` null handling.

Issue: https://github.com/naatin777/GitoGito/issues/189

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Biome as the default code formatter and linter with automatic formatting on save across VS Code and Zed editors.
  * Integrated Lefthook for automated pre-commit code checks and formatting.
  * Updated build and development scripts to use Biome and TypeScript for code quality.
  * Removed IDE-specific configuration directories from Git ignore list.

* **Refactor**
  * Refactored terminal UI runner functions for improved code organization.
  * Standardized code formatting across the codebase through import reorganization and statement restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->